### PR TITLE
Initial Processor proposal

### DIFF
--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "thrift": "^0.10.0",
-    "typescript": "^2.4.2"
+    "typescript": "^2.4.2",
+    "q": "1.0.x"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/thrift-server-core/src/Processor.ts
+++ b/packages/thrift-server-core/src/Processor.ts
@@ -1,0 +1,71 @@
+import {
+  MessageType,
+  TApplicationException,
+  TApplicationExceptionType,
+  Type,
+} from 'thrift'
+
+import * as Q from 'q'
+
+class Processor {
+  private handlers: any
+  private namespace: any
+
+  constructor(namespace, handlers) {
+    this.namespace = namespace
+    // TODO: default handlers or error?
+    this.handlers = handlers
+  }
+
+  public process(input, output) {
+    const { fname, seqid, rseqid } = input.readMessageBegin()
+    const handler = this.handlers[fname]
+    // TODO: Needs to be generated and exposed on `namespace`
+    const Args = this.namespace[`${fname}_args`]
+    // TODO: Needs to be generated and exposed on `namespace`
+    const Result = this.namespace[`${fname}_result`]
+    // TODO: Needs to be generated and exposed on `namespace`
+    const Err = this.namespace[`${fname}_error`]
+    if (typeof handler === 'function') {
+      const args = new Args()
+      args.read(input)
+      input.readMessageEnd()
+      Q.fcall(handler, args)
+        .then((result) => {
+          // This handles `oneway`
+          if (!Result) {
+            return
+          }
+          const resultObj = new Result({success: result})
+          output.writeMessageBegin(fname, MessageType.REPLY, seqid)
+          resultObj.write(output)
+          output.writeMessageEnd()
+          output.flush()
+        }, (err) => {
+          // TODO: How does `oneway` handle `throws`?
+          if (!Err) {
+            return
+          }
+          const result = new Err(err)
+          let type
+          if (result.unknown) {
+            type = MessageType.EXCEPTION
+          } else {
+            type = MessageType.REPLY
+          }
+          output.writeMessageBegin(fname, type, seqid)
+          result.write(output)
+          output.writeMessageEnd()
+          output.flush()
+        })
+    }
+
+    input.skip(Type.STRUCT)
+    input.readMessageEnd()
+    const x = new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD, 'Unknown function ' + fname)
+    output.writeMessageBegin(fname, MessageType.EXCEPTION, rseqid)
+    x.write(output)
+    output.writeMessageEnd()
+    output.flush()
+  }
+}


### PR DESCRIPTION
This is my initial proposal for a non-generated Processor class.

While working on the implementation, I prototyped some usage examples that seem like a nice API:
```ts
import { createProcessor } from 'thrift-server-core'
// Calculator namespace exposes `ping_args`/`ping_result`/`ping_error` &
// `add_args`/`add_result`/`add_error`
// This naming can be adjusted
import { Calculator } from './generated-code'

const handlers = {
    ping() { ... },
    add(args, context) { ... }
}

// This is passed to the express or hapi plugins
const processor = createProcessor(Calculator, handlers)
```

I believe those same exported classes can be used with a non-generated Client implementation with a similar API:
```ts
// `connection` is a class for http or websocket, etc
const client = createClient(Calculator, connection)
```

What do y'all think? @ian-harshman-ck @nnance @kevinbgreene 