### PR TITLE
Lerna Independent Publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "lerna": "2.0.0",
+  "lerna": "2.1.0",
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^8.0.23",
     "code": "^4.1.0",
     "lab": "^14.2.0",
-    "lerna": "^2.0.0",
+    "lerna": "^2.1.0",
     "rimraf": "^2.6.1",
     "tslint": "^5.6.0",
     "tslint-eslint-rules": "^4.1.1",


### PR DESCRIPTION
Using independent mode in Lerna so that packages can be published / prepublished independently, until we are ready to tie them together.

Once we are ready to publish server versions that are integrated with core, we can re-initialize lerna to locked mode.