### PR TITLE
Stream transports

### DIFF
--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -38,6 +38,7 @@
     "tslint-eslint-rules": "^4.1.1"
   },
   "dependencies": {
+    "frame-stream": "^1.1.1",
     "promised-read": "^1.0.1",
     "q": "1.0.x",
     "thrift": "^0.10.0",

--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "thrift": "^0.10.0",
-    "typescript": "^2.4.2"
+    "typescript": "^2.4.2",
+    "q": "1.0.x"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "frame-stream": "^1.1.1",
+    "from2": "^2.3.0",
     "promised-read": "^1.0.1",
     "q": "1.0.x",
     "thrift": "^0.10.0",

--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -38,9 +38,10 @@
     "tslint-eslint-rules": "^4.1.1"
   },
   "dependencies": {
+    "promised-read": "^1.0.1",
+    "q": "1.0.x",
     "thrift": "^0.10.0",
-    "typescript": "^2.4.2",
-    "q": "1.0.x"
+    "typescript": "^2.4.2"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/thrift-server-core/src/Processor.ts
+++ b/packages/thrift-server-core/src/Processor.ts
@@ -1,0 +1,71 @@
+import {
+  MessageType,
+  TApplicationException,
+  TApplicationExceptionType,
+  Type,
+} from 'thrift'
+
+import * as Q from 'q'
+
+class Processor {
+  private handlers: any
+  private namespace: any
+
+  constructor(namespace, handlers) {
+    this.namespace = namespace
+    // TODO: default handlers or error?
+    this.handlers = handlers
+  }
+
+  public process(input, output) {
+    const { fname, seqid, rseqid } = input.readMessageBegin()
+    const handler = this.handlers[fname]
+    // TODO: Needs to be generated and exposed on `namespace`
+    const Args = this.namespace[`${fname}_args`]
+    // TODO: Needs to be generated and exposed on `namespace`
+    const Result = this.namespace[`${fname}_result`]
+    // TODO: Needs to be generated and exposed on `namespace`
+    const Err = this.namespace[`${fname}_error`]
+    if (typeof handler === 'function') {
+      const args = new Args()
+      args.read(input)
+      input.readMessageEnd()
+      Q.fcall(handler, args)
+        .then((result) => {
+          // This handles `oneway`
+          if (!Result) {
+            return
+          }
+          const resultObj = new Result({success: result})
+          output.writeMessageBegin(fname, MessageType.REPLY, seqid)
+          resultObj.write(output)
+          output.writeMessageEnd()
+          output.flush()
+        }, (err) => {
+          // TODO: How does `oneway` handle `throws`?
+          if (!Err) {
+            return
+          }
+          const result = new Err(err)
+          let type
+          if (result.unknown) {
+            type = MessageType.EXCEPTION
+          } else {
+            type = MessageType.REPLY
+          }
+          output.writeMessageBegin(fname, type, seqid)
+          result.write(output)
+          output.writeMessageEnd()
+          output.flush()
+        })
+    }
+
+    input.skip(Type.STRUCT)
+    input.readMessageEnd()
+    const x = new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD, 'Unknown function ' + fname)
+    output.writeMessageBegin(fname, MessageType.EXCEPTION, rseqid)
+    x.write(output)
+    output.writeMessageEnd()
+    output.flush()
+  }
+}

--- a/packages/thrift-server-core/src/index.ts
+++ b/packages/thrift-server-core/src/index.ts
@@ -55,20 +55,17 @@ export function isProtocolSupported(protocol: string): boolean {
 }
 
 // TODO: What should this Promise be typed as?
-export function process(processor, stream, Transport, Protocol): Promise<any> {
-  const transportWithData = new Transport(stream)
-  const input = new Protocol(transportWithData)
+// TODO: More importantly, what should be returned? status code or something?
+export async function process(processor, stream, Transport, Protocol): Promise<void> {
+  const transport = new Transport(stream)
+  const protocol = new Protocol(transport)
 
-  return new Promise(async (resolve, reject) => {
-    const output = new Protocol(new Transport(undefined, resolve))
-
-    try {
-      await processor.process(input, output)
-    } catch (err) {
-      if (err instanceof InputBufferUnderrunError) {
-        // TODO: How does this differ?
-      }
-      reject(err)
+  try {
+    await processor.process(protocol)
+  } catch (err) {
+    if (err instanceof InputBufferUnderrunError) {
+      // TODO: How does this differ?
     }
-  })
+    throw err
+  }
 }

--- a/packages/thrift-server-core/src/index.ts
+++ b/packages/thrift-server-core/src/index.ts
@@ -1,7 +1,8 @@
-import TFramedTransport = require('thrift/lib/nodejs/lib/thrift/framed_transport')
 import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift/input_buffer_underrun_error')
+
 // New implementation
 import BufferedTransport from './transports/BufferedTransport'
+import FramedTransport from './transports/FramedTransport'
 
 import TCompactProtocol = require('thrift/lib/nodejs/lib/thrift/compact_protocol')
 import TJSONProtocol = require('thrift/lib/nodejs/lib/thrift/json_protocol')
@@ -10,8 +11,7 @@ import BinaryProtocol from './protocols/BinaryProtocol'
 
 const transports = {
   buffered: BufferedTransport,
-  // Still old impl
-  framed: TFramedTransport,
+  framed: FramedTransport,
 }
 // TODO: Is there a better way to make nice error messages in plugins without exporting this?
 export const supportedTransports = Object.keys(transports)
@@ -64,10 +64,9 @@ export function process(processor, stream, Transport, Protocol): Promise<any> {
 
     try {
       await processor.process(input, output)
-      transportWithData.commitPosition()
     } catch (err) {
       if (err instanceof InputBufferUnderrunError) {
-        transportWithData.rollbackPosition()
+        // TODO: How does this differ?
       }
       reject(err)
     }

--- a/packages/thrift-server-core/src/protocols/BinaryProtocol.ts
+++ b/packages/thrift-server-core/src/protocols/BinaryProtocol.ts
@@ -1,0 +1,269 @@
+import Thrift = require('thrift/lib/nodejs/lib/thrift/thrift')
+
+import { ITransport } from '../transports/Transport'
+
+export interface IProtocol {
+  // TODO: Just proxies to transport flush
+  flush(): void
+
+  // TODO: no seqid?
+  writeMessageBegin(name, type, seqid): void
+  writeMessageEnd(): void
+
+  // TODO: not implemented
+  writeStructBegin(name): void
+  writeStructEnd(): void
+
+  // TODO: no seqid?
+  writeFieldBegin(name, type, id): void
+  // TODO: not implemented
+  writeFieldEnd(): void
+  writeFieldStop(): void
+
+  writeMapBegin(ktype, vtype, size): void
+  writeMapEnd(): void
+
+  writeListBegin(etype, size): void
+  writeListEnd(): void
+
+  writeSetBegin(etype, size): void
+  writeSetEnd(): void
+
+  writeBool(value: boolean): void
+  writeByte(value: number): void
+  writeI16(value: number): void
+  writeI32(value: number): void
+  writeI64(value: number): void
+  writeDouble(value: number): void
+  // TODO: avoid this abstraction
+  writeStringOrBinary(name, encoding, arg): void
+  writeString(value: string): void
+  writeBinary(value: Buffer): void
+
+  // TODO: concrete return type
+  readMessageBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readMessageEnd(): void
+
+  // TODO: concrete return type
+  readStructBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readStructEnd(): void
+
+  // TODO: concrete return type
+  readFieldBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readFieldEnd(): void
+
+  // TODO: concrete return type
+  readMapBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readMapEnd(): void
+
+  // TODO: concrete return type
+  readListBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readListEnd(): void
+
+  // TODO: concrete return type
+  readSetBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readSetEnd(): void
+
+  readBool(): Promise<boolean>
+  readByte(): Promise<number>
+  readI16(): Promise<number>
+  readI32(): Promise<number>
+  readI64(): Promise<number>
+  readDouble(): Promise<number>
+  readBinary(): Promise<Buffer>
+  readString(): Promise<string>
+
+  // TODO: is this needed?
+  getTransport(): ITransport
+
+  // TODO: type this argument
+  skip(type): void
+}
+
+export class BinaryProtocol implements IProtocol {
+  private transport: ITransport
+
+  constructor(transport: ITransport) {
+    this.transport = transport
+  }
+
+  public flush(): void {
+    throw new Error('Method not implemented.')
+  }
+
+  public writeMessageBegin(name: any, type: any, seqid: any): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeMessageEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeStructBegin(name: any): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeStructEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeFieldBegin(name: any, type: any, id: any): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeFieldEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeFieldStop(): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeMapBegin(ktype: any, vtype: any, size: any): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeMapEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeListBegin(etype: any, size: any): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeListEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeSetBegin(etype: any, size: any): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeSetEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeBool(value: boolean): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeByte(value: number): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeI16(value: number): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeI32(value: number): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeI64(value: number): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeDouble(value: number): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeStringOrBinary(name: any, encoding: any, arg: any): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeString(value: string): void {
+    throw new Error('Method not implemented.')
+  }
+  public writeBinary(value: Buffer): void {
+    throw new Error('Method not implemented.')
+  }
+  public readMessageBegin(): Promise<any> {
+    throw new Error('Method not implemented.')
+  }
+  public readMessageEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public readStructBegin(): Promise<any> {
+    throw new Error('Method not implemented.')
+  }
+  public readStructEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public readFieldBegin(): Promise<any> {
+    throw new Error('Method not implemented.')
+  }
+  public readFieldEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public readMapBegin(): Promise<any> {
+    throw new Error('Method not implemented.')
+  }
+  public readMapEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public readListBegin(): Promise<any> {
+    throw new Error('Method not implemented.')
+  }
+  public readListEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public readSetBegin(): Promise<any> {
+    throw new Error('Method not implemented.')
+  }
+  public readSetEnd(): void {
+    throw new Error('Method not implemented.')
+  }
+  public readBool(): Promise<boolean> {
+    // TODO: Is this better as Promise.resolve and tag the readBool method as async?
+    return new Promise(async (resolve) => {
+      const byte = await this.transport.readByte()
+      const bool = (byte === 0) ? false : true
+      resolve(bool)
+    })
+  }
+  public readByte(): Promise<number> {
+    return this.transport.readByte()
+  }
+  public readI16(): Promise<number> {
+    return this.transport.readI16()
+  }
+  public readI32(): Promise<number> {
+    return this.transport.readI32()
+  }
+  public readI64(): Promise<number> {
+    // TODO: Why doesn't the transport define this?
+    throw new Error('Method not implemented.')
+  }
+  public readDouble(): Promise<number> {
+    return this.transport.readDouble()
+  }
+  public readBinary(): Promise<Buffer> {
+    return new Promise(async (resolve) => {
+      const size = await this.transport.readI32()
+      // TODO: Can this be incorporated into the transport.readBuffer method?
+      if (size === 0) {
+        return resolve(Buffer.alloc(0))
+      }
+
+      // TODO: Is this just guarding an underrun?
+      if (size < 0) {
+        throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.NEGATIVE_SIZE, 'Negative binary size')
+      }
+      resolve(this.transport.read(size))
+    })
+  }
+  public readString(): Promise<string> {
+    return new Promise(async (resolve) => {
+      const size = await this.transport.readI32()
+      // TODO: Can this be incorporated into the transport.readString method?
+      if (size === 0) {
+        return resolve('')
+      }
+
+      // TODO: Is this just guarding an underrun?
+      if (size < 0) {
+        throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.NEGATIVE_SIZE, 'Negative string size')
+      }
+      resolve(this.transport.readString(size))
+    })
+  }
+  // TODO: Where is this used? Maybe we can get rid of it
+  public getTransport(): ITransport {
+    return this.transport
+  }
+  public skip(type: any): void {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/packages/thrift-server-core/src/protocols/Protocol.ts
+++ b/packages/thrift-server-core/src/protocols/Protocol.ts
@@ -1,0 +1,98 @@
+import { ITransport } from '../transports/Transport'
+
+export interface IProtocol {
+  // TODO: Just proxies to transport flush
+  flush(): void
+
+  // TODO: no seqid?
+  // TODO: Ensure these arguments have proper typings
+  writeMessageBegin(name: string, type: number, seqid: number): void
+  writeMessageEnd(): void
+
+  // TODO: not implemented
+  writeStructBegin(name): void
+  writeStructEnd(): void
+
+  // TODO: no seqid?
+  // TODO: Ensure these arguments have proper typings
+  writeFieldBegin(name: string, type: number, id: number): void
+  // TODO: not implemented
+  writeFieldEnd(): void
+  writeFieldStop(): void
+
+  // TODO: Ensure these arguments have proper typings
+  writeMapBegin(ktype: number, vtype: number, size: number): void
+  writeMapEnd(): void
+
+  // TODO: Ensure these arguments have proper typings
+  writeListBegin(etype: number, size: number): void
+  writeListEnd(): void
+
+  // TODO: Ensure these arguments have proper typings
+  writeSetBegin(etype: number, size: number): void
+  writeSetEnd(): void
+
+  writeBool(value: boolean): void
+  writeByte(value: number): void
+  writeI16(value: number): void
+  writeI32(value: number): void
+  writeI64(value: number): void
+  writeDouble(value: number): void
+  // TODO: avoid this abstraction
+  // writeStringOrBinary(name, encoding, arg): void
+  writeString(value: string): void
+  // TODO: Should this be pushed into the Transport?
+  writeBinary(value: Buffer): void
+
+  // TODO: concrete return type
+  readMessageBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readMessageEnd(): void
+
+  // TODO: concrete return type
+  readStructBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readStructEnd(): void
+
+  // TODO: concrete return type
+  readFieldBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readFieldEnd(): void
+
+  // TODO: concrete return type
+  readMapBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readMapEnd(): void
+
+  // TODO: concrete return type
+  readListBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readListEnd(): void
+
+  // TODO: concrete return type
+  readSetBegin(): Promise<any>
+  // TODO: not implemented
+  // Should these return promises?
+  readSetEnd(): void
+
+  readBool(): Promise<boolean>
+  readByte(): Promise<number>
+  readI16(): Promise<number>
+  readI32(): Promise<number>
+  readI64(): Promise<number>
+  readDouble(): Promise<number>
+  // TODO: Should this be pushed into the Transport?
+  readBinary(): Promise<Buffer>
+  readString(): Promise<string>
+
+  // TODO: is this needed?
+  getTransport(): ITransport
+
+  // TODO: type this argument
+  skip(type): void
+}

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -12,8 +12,13 @@ export default class BufferedTransport implements ITransport {
   private outBuffers: Buffer[] = []
   private outSize: number = 0
 
-  constructor() {
+  constructor(input: Buffer | undefined) {
     this.inBuf = Buffer.alloc(this.defaultReadBufferSize)
+
+    if (Buffer.isBuffer(input)) {
+      input.copy(this.inBuf, this.writeCursor, 0)
+    }
+    this.writeCursor += this.inBuf.length
     // this.onFlush = callback;
   }
 

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -1,13 +1,15 @@
 import { Buffer } from 'buffer'
-import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift//input_buffer_underrun_error')
 import binary = require('thrift/lib/nodejs/lib/thrift/binary')
+import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift/input_buffer_underrun_error')
 
-export class BufferedTransport {
+import { ITransport } from './Transport'
+
+export default class BufferedTransport implements ITransport {
   private readCursor: number = 0
   private writeCursor: number = 0 // for input buffer
   private inBuf: Buffer
   private defaultReadBufferSize: number = 1024
-  private outBuffers: Array<Buffer> = []
+  private outBuffers: Buffer[] = []
   private outSize: number = 0
 
   constructor() {

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -33,7 +33,7 @@ export default class BufferedTransport implements ITransport {
     }
 
     if (chunk.length < size || chunk.length > size) {
-      throw new Error(`Wrong size. Expected: ${size} but got ${chunk}`)
+      throw new Error(`Wrong size. Expected: ${size} but got ${chunk.length}`)
     }
 
     return chunk
@@ -66,7 +66,6 @@ export default class BufferedTransport implements ITransport {
     })
 
     if (this.onFlush) {
-      // Passing seqid through this call to get it to the connection
       this.onFlush(msg)
     }
 

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -24,7 +24,7 @@ export class BufferedTransport {
   public commitPosition(): void {
     const unreadSize = this.writeCursor - this.readCursor
     const bufSize = (unreadSize * 2 > this.defaultReadBufferSize) ? unreadSize * 2 : this.defaultReadBufferSize
-    const buf = new Buffer(bufSize)
+    const buf = Buffer.alloc(bufSize)
     if (unreadSize > 0) {
       // TODO: Does this actually need to be copied? If not, it could be sliced
       this.inBuf.copy(buf, 0, this.readCursor, this.writeCursor)
@@ -46,7 +46,7 @@ export class BufferedTransport {
 
   public read(size: number): Buffer {
     this.ensureAvailable(size)
-    const buf = new Buffer(size)
+    const buf = Buffer.alloc(size)
     // TODO: Does this actually need to be copied? If not, it could be sliced
     this.inBuf.copy(buf, 0, this.readCursor, this.readCursor + size)
     this.readCursor += size
@@ -85,7 +85,7 @@ export class BufferedTransport {
   // TODO: Should we de-support string?
   public write(buf: Buffer | string): void {
     if (typeof buf === 'string') {
-      buf = new Buffer(buf, 'utf8')
+      buf = Buffer.from(buf, 'utf8')
     }
     this.outBuffers.push(buf)
     this.outSize += buf.length
@@ -104,7 +104,7 @@ export class BufferedTransport {
       return
     }
 
-    const msg = new Buffer(this.outSize)
+    const msg = Buffer.alloc(this.outSize)
     let pos = 0
     this.outBuffers.forEach((buf) => {
       // TODO: Do these actually need to be copied? If not, it could be joined by Buffer.concat

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -1,0 +1,142 @@
+import { Buffer } from 'buffer'
+import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift//input_buffer_underrun_error')
+import binary = require('thrift/lib/nodejs/lib/thrift/binary')
+
+export class BufferedTransport {
+  private readCursor: number = 0
+  private writeCursor: number = 0 // for input buffer
+  private inBuf: Buffer
+  private defaultReadBufferSize: number = 1024
+  private outBuffers: Buffer[] = []
+  private outSize: number = 0
+
+  constructor() {
+    this.inBuf = Buffer.alloc(this.defaultReadBufferSize)
+    // this.onFlush = callback;
+  }
+
+  // Set the seqid of the message in the client
+  // So that callbacks can be found
+  // setSeqId(seqid) {
+  //   this._seqid = seqid;
+  // }
+
+  public commitPosition(): void {
+    const unreadSize = this.writeCursor - this.readCursor
+    const bufSize = (unreadSize * 2 > this.defaultReadBufferSize) ? unreadSize * 2 : this.defaultReadBufferSize
+    const buf = new Buffer(bufSize)
+    if (unreadSize > 0) {
+      // TODO: Does this actually need to be copied? If not, it could be sliced
+      this.inBuf.copy(buf, 0, this.readCursor, this.writeCursor)
+    }
+    this.readCursor = 0
+    this.writeCursor = unreadSize
+    this.inBuf = buf
+  }
+
+  public rollbackPosition(): void {
+    this.readCursor = 0
+  }
+
+  public ensureAvailable(size: number): void {
+    if (this.readCursor + size > this.writeCursor) {
+      throw new InputBufferUnderrunError()
+    }
+  }
+
+  public read(size: number): Buffer {
+    this.ensureAvailable(size)
+    const buf = new Buffer(size)
+    // TODO: Does this actually need to be copied? If not, it could be sliced
+    this.inBuf.copy(buf, 0, this.readCursor, this.readCursor + size)
+    this.readCursor += size
+    return buf
+  }
+
+  public readByte(): number {
+    this.ensureAvailable(1)
+    return binary.readByte(this.inBuf[this.readCursor++])
+  }
+  public readI16(): number {
+    this.ensureAvailable(2)
+    const i16 = binary.readI16(this.inBuf, this.readCursor)
+    this.readCursor += 2
+    return i16
+  }
+  public readI32(): number {
+    this.ensureAvailable(4)
+    const i32 = binary.readI32(this.inBuf, this.readCursor)
+    this.readCursor += 4
+    return i32
+  }
+  public readDouble(): number {
+    this.ensureAvailable(8)
+    const d = binary.readDouble(this.inBuf, this.readCursor)
+    this.readCursor += 8
+    return d
+  }
+  public readString(size: number): string {
+    this.ensureAvailable(size)
+    const str = this.inBuf.toString('utf8', this.readCursor, this.readCursor + size)
+    this.readCursor += size
+    return str
+  }
+
+  // TODO: Should we de-support string?
+  public write(buf: Buffer | string): void {
+    if (typeof buf === 'string') {
+      buf = new Buffer(buf, 'utf8')
+    }
+    this.outBuffers.push(buf)
+    this.outSize += buf.length
+  }
+
+  // TODO: Maybe this should return a promise
+  public flush(): void {
+    // TODO: This doesn't seem used
+    // If the seqid of the callback is available pass it to the onFlush
+    // Then remove the current seqid
+    // const seqid = this._seqid
+    // this._seqid = null
+
+    // TODO: If this returns a promise, should this resolve or reject?
+    if (this.outSize < 1) {
+      return
+    }
+
+    const msg = new Buffer(this.outSize)
+    let pos = 0
+    this.outBuffers.forEach((buf) => {
+      // TODO: Do these actually need to be copied? If not, it could be joined by Buffer.concat
+      buf.copy(msg, pos, 0)
+      pos += buf.length
+    })
+
+    // if (this.onFlush) {
+    //   // Passing seqid through this call to get it to the connection
+    //   this.onFlush(msg, seqid)
+    // }
+
+    this.outBuffers = []
+    this.outSize = 0
+  }
+
+  public consume(bytesConsumed: number): void {
+    this.readCursor += bytesConsumed
+  }
+
+  // TODO: This seems to only be used for json_protocol
+  public borrow(): { buf: Buffer; readIndex: number; writeIndex: number; } {
+    const obj = {buf: this.inBuf, readIndex: this.readCursor, writeIndex: this.writeCursor}
+    return obj
+  }
+
+  // TODO: They don't implement these
+  public isOpen(): boolean {
+    return true
+  }
+  // tslint:disable-next-line:no-empty
+  public open() {}
+  // tslint:disable-next-line:no-empty
+  public close() {}
+}

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -57,101 +57,9 @@ export default class BufferedTransport implements ITransport {
     })
   }
 
-  public readByte(): Promise<number> {
-    return new Promise((resolve) => {
-      this.ensureAvailable(1)
-
-      const byte = binary.readByte(this.inBuf[this.readCursor])
-      this.readCursor += 1
-      resolve(byte)
-    })
-  }
-  // TODO: Is this better to duplicate from readByte to not couple the methods?
-  public readBool(): Promise<boolean> {
-    return new Promise((resolve) => {
-      this.ensureAvailable(1)
-
-      const byte = binary.readByte(this.inBuf[this.readCursor])
-      this.readCursor += 1
-      const bool = (byte === 0) ? false : true
-      resolve(bool)
-    })
-  }
-  public readI16(): Promise<number> {
-    return new Promise((resolve) => {
-      this.ensureAvailable(2)
-
-      const i16 = binary.readI16(this.inBuf, this.readCursor)
-      this.readCursor += 2
-      resolve(i16)
-    })
-  }
-  public readI32(): Promise<number> {
-    return new Promise((resolve) => {
-      this.ensureAvailable(4)
-
-      const i32 = binary.readI32(this.inBuf, this.readCursor)
-      this.readCursor += 4
-      resolve(i32)
-    })
-  }
-  public readDouble(): Promise<number> {
-    return new Promise((resolve) => {
-      this.ensureAvailable(8)
-
-      const d = binary.readDouble(this.inBuf, this.readCursor)
-      this.readCursor += 8
-      resolve(d)
-    })
-  }
-  public readString(size: number): Promise<string> {
-    return new Promise((resolve) => {
-      this.ensureAvailable(size)
-
-      const str = this.inBuf.toString('utf8', this.readCursor, this.readCursor + size)
-      this.readCursor += size
-      resolve(str)
-    })
-  }
-
-  // TODO: Should we de-support string?
-  public write(buf: Buffer | string): void {
-    if (typeof buf === 'string') {
-      buf = Buffer.from(buf, 'utf8')
-    }
+  public write(buf: Buffer): void {
     this.outBuffers.push(buf)
     this.outSize += buf.length
-  }
-  public writeByte(value: number): void {
-    // TODO: Is this correct? Yay buffers
-    const buf = Buffer.alloc(1)
-    buf.writeUInt8(value, 0)
-    this.write(buf)
-  }
-  // TODO: Is this better to duplicate from writeByte to not couple the methods?
-  public writeBool(value: boolean): void {
-    const byte = value ? 1 : 0
-    const buf = Buffer.alloc(1)
-    buf.writeUInt8(byte, 0)
-    this.write(buf)
-  }
-  public writeI16(value: number): void {
-    this.write(binary.writeI16(Buffer.alloc(2), value))
-    // const buf = Buffer.alloc(2)
-    // // TODO: LE or BE? If I'm reading "binary" properly, looks like BE
-    // buf.writeInt16BE(value, 0)
-    // this.write(buf)
-  }
-  public writeI32(value: number): void {
-    this.write(binary.writeI32(Buffer.alloc(4), value))
-  }
-  public writeDouble(value: number): void {
-    this.write(binary.writeDouble(Buffer.alloc(8), value))
-  }
-  public writeString(value: string): void {
-    const buf = Buffer.from(value, 'utf8')
-    this.writeI32(buf.length)
-    this.write(buf)
   }
 
   // TODO: Maybe this should return a promise
@@ -184,17 +92,20 @@ export default class BufferedTransport implements ITransport {
     this.outSize = 0
   }
 
+  // TODO: Might not be needed
   public consume(bytesConsumed: number): void {
     this.readCursor += bytesConsumed
   }
 
   // TODO: This seems to only be used for json_protocol
+  // TODO: Might not be needed
   public borrow(): { buf: Buffer; readIndex: number; writeIndex: number; } {
     const obj = {buf: this.inBuf, readIndex: this.readCursor, writeIndex: this.writeCursor}
     return obj
   }
 
   // TODO: They don't implement these
+  // TODO: This is probably not needed
   public isOpen(): boolean {
     return true
   }

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -1,5 +1,4 @@
 import { Buffer } from 'buffer'
-import binary = require('thrift/lib/nodejs/lib/thrift/binary')
 import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift/input_buffer_underrun_error')
 
 import { ITransport } from './Transport'

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -122,6 +122,37 @@ export default class BufferedTransport implements ITransport {
     this.outBuffers.push(buf)
     this.outSize += buf.length
   }
+  public writeByte(value: number): void {
+    // TODO: Is this correct? Yay buffers
+    const buf = Buffer.alloc(1)
+    buf.writeUInt8(value, 0)
+    this.write(buf)
+  }
+  // TODO: Is this better to duplicate from writeByte to not couple the methods?
+  public writeBool(value: boolean): void {
+    const byte = value ? 1 : 0
+    const buf = Buffer.alloc(1)
+    buf.writeUInt8(byte, 0)
+    this.write(buf)
+  }
+  public writeI16(value: number): void {
+    this.write(binary.writeI16(Buffer.alloc(2), value))
+    // const buf = Buffer.alloc(2)
+    // // TODO: LE or BE? If I'm reading "binary" properly, looks like BE
+    // buf.writeInt16BE(value, 0)
+    // this.write(buf)
+  }
+  public writeI32(value: number): void {
+    this.write(binary.writeI32(Buffer.alloc(4), value))
+  }
+  public writeDouble(value: number): void {
+    this.write(binary.writeDouble(Buffer.alloc(8), value))
+  }
+  public writeString(value: string): void {
+    const buf = Buffer.from(value, 'utf8')
+    this.writeI32(buf.length)
+    this.write(buf)
+  }
 
   // TODO: Maybe this should return a promise
   public flush(): void {

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -44,6 +44,9 @@ export class BufferedTransport {
     }
   }
 
+  // TODO: Should the `read*` methods return a promise since they can fail with an Underrun error?
+  // Currently they throw, which can't be documented with typescript types
+  // These methods aren't currently async in buffered/framed transports but others might be in the future
   public read(size: number): Buffer {
     this.ensureAvailable(size)
     const buf = Buffer.alloc(size)

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -66,6 +66,17 @@ export default class BufferedTransport implements ITransport {
       resolve(byte)
     })
   }
+  // TODO: Is this better to duplicate from readByte to not couple the methods?
+  public readBool(): Promise<boolean> {
+    return new Promise((resolve) => {
+      this.ensureAvailable(1)
+
+      const byte = binary.readByte(this.inBuf[this.readCursor])
+      this.readCursor += 1
+      const bool = (byte === 0) ? false : true
+      resolve(bool)
+    })
+  }
   public readI16(): Promise<number> {
     return new Promise((resolve) => {
       this.ensureAvailable(2)

--- a/packages/thrift-server-core/src/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/transports/BufferedTransport.ts
@@ -1,24 +1,21 @@
 import { Buffer } from 'buffer'
 import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift/input_buffer_underrun_error')
 
+// TODO: Replace with custom/better implementation
+import { read as streamRead } from 'promised-read'
+
 import { ITransport } from './Transport'
 
 export default class BufferedTransport implements ITransport {
-  private readCursor: number = 0
-  private writeCursor: number = 0 // for input buffer
-  private inBuf: Buffer
-  private defaultReadBufferSize: number = 1024
+  private stream: NodeJS.ReadWriteStream
   private outBuffers: Buffer[] = []
   private outSize: number = 0
+  private onFlush
 
-  constructor(input: Buffer | undefined) {
-    this.inBuf = Buffer.alloc(this.defaultReadBufferSize)
-
-    if (Buffer.isBuffer(input)) {
-      input.copy(this.inBuf, this.writeCursor, 0)
-    }
-    this.writeCursor += this.inBuf.length
-    // this.onFlush = callback;
+  constructor(input: NodeJS.ReadWriteStream, callback) {
+    this.stream = input
+    // TODO: Utilize duplex stream for writing instead of this onFlush
+    this.onFlush = callback
   }
 
   // Set the seqid of the message in the client
@@ -27,33 +24,19 @@ export default class BufferedTransport implements ITransport {
   //   this._seqid = seqid;
   // }
 
-  public commitPosition(): void {
-    const unreadSize = this.writeCursor - this.readCursor
-    const bufSize = (unreadSize * 2 > this.defaultReadBufferSize) ? unreadSize * 2 : this.defaultReadBufferSize
-    const buf = Buffer.alloc(bufSize)
-    if (unreadSize > 0) {
-      // TODO: Does this actually need to be copied? If not, it could be sliced
-      this.inBuf.copy(buf, 0, this.readCursor, this.writeCursor)
+  public async read(size: number): Promise<Buffer | undefined> {
+    const chunk = await streamRead(this.stream, size)
+
+    // Stream done, no more data
+    if (chunk === null) {
+      return
     }
-    this.readCursor = 0
-    this.writeCursor = unreadSize
-    this.inBuf = buf
-  }
 
-  public rollbackPosition(): void {
-    this.readCursor = 0
-  }
+    if (chunk.length < size || chunk.length > size) {
+      throw new Error(`Wrong size. Expected: ${size} but got ${chunk}`)
+    }
 
-  public read(size: number): Promise<Buffer> {
-    return new Promise((resolve) => {
-      this.ensureAvailable(size)
-
-      const buf = Buffer.alloc(size)
-      // TODO: Does this actually need to be copied? If not, it could be sliced
-      this.inBuf.copy(buf, 0, this.readCursor, this.readCursor + size)
-      this.readCursor += size
-      resolve(buf)
-    })
+    return chunk
   }
 
   public write(buf: Buffer): void {
@@ -82,25 +65,13 @@ export default class BufferedTransport implements ITransport {
       pos += buf.length
     })
 
-    // if (this.onFlush) {
-    //   // Passing seqid through this call to get it to the connection
-    //   this.onFlush(msg, seqid)
-    // }
+    if (this.onFlush) {
+      // Passing seqid through this call to get it to the connection
+      this.onFlush(msg)
+    }
 
     this.outBuffers = []
     this.outSize = 0
-  }
-
-  // TODO: Might not be needed
-  public consume(bytesConsumed: number): void {
-    this.readCursor += bytesConsumed
-  }
-
-  // TODO: This seems to only be used for json_protocol
-  // TODO: Might not be needed
-  public borrow(): { buf: Buffer; readIndex: number; writeIndex: number; } {
-    const obj = {buf: this.inBuf, readIndex: this.readCursor, writeIndex: this.writeCursor}
-    return obj
   }
 
   // TODO: They don't implement these
@@ -112,11 +83,4 @@ export default class BufferedTransport implements ITransport {
   public open() {}
   // tslint:disable-next-line:no-empty
   public close() {}
-
-  // By making this private and only using it inside promise constructors, it should be fine to throw
-  private ensureAvailable(size: number): void {
-    if (this.readCursor + size > this.writeCursor) {
-      throw new InputBufferUnderrunError()
-    }
-  }
 }

--- a/packages/thrift-server-core/src/transports/FramedTransport.ts
+++ b/packages/thrift-server-core/src/transports/FramedTransport.ts
@@ -1,0 +1,68 @@
+import binary = require('thrift/lib/nodejs/lib/thrift/binary')
+import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift/input_buffer_underrun_error')
+
+import { ITransport } from './Transport'
+
+const HEADER_SIZE = 4
+
+export default class FramedTransport implements ITransport {
+  private inBuf: Buffer
+  private readCursor: number
+
+  constructor(input: Buffer | undefined) {
+    this.inBuf = input
+  }
+
+  public read(size: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      this.ensureAvailable(HEADER_SIZE)
+      // TODO: Does this actually need to be copied? If not, it could be sliced
+      const header = this.inBuf.slice(0, HEADER_SIZE) // 4 is frame header size
+      this.readCursor += HEADER_SIZE
+
+      const frameSize = binary.readI32(header, 0)
+
+      this.ensureAvailable(size)
+      const chunk = this.inBuf.slice(this.readCursor, this.readCursor + size)
+      this.readCursor += size
+      resolve(chunk)
+    })
+  }
+
+  // tslint:disable-next-line:no-empty
+  public write() {
+
+  }
+
+  // tslint:disable-next-line:no-empty
+  public flush() {
+
+  }
+
+  // tslint:disable-next-line:no-empty
+  public consume() {}
+  // tslint:disable-next-line:no-empty
+  public borrow(): { buf: Buffer; readIndex: number; writeIndex: number; } {
+    return { buf: Buffer.alloc(0), readIndex: 0, writeIndex: 0 }
+  }
+  // tslint:disable-next-line:no-empty
+  public commitPosition() {}
+  // tslint:disable-next-line:no-empty
+  public rollbackPosition() {}
+
+  public isOpen(): boolean {
+    return true
+  }
+
+  // tslint:disable-next-line:no-empty
+  public open() {}
+
+  // tslint:disable-next-line:no-empty
+  public close() {}
+
+  private ensureAvailable(size) {
+    if (this.readCursor + size > this.inBuf.length) {
+      throw new InputBufferUnderrunError()
+    }
+  }
+}

--- a/packages/thrift-server-core/src/transports/Transport.ts
+++ b/packages/thrift-server-core/src/transports/Transport.ts
@@ -4,6 +4,7 @@ export interface ITransport {
 
   read(size: number): Promise<Buffer>
   readByte(): Promise<number>
+  readBool(): Promise<boolean>
   readI16(): Promise<number>
   readI32(): Promise<number>
   readDouble(): Promise<number>

--- a/packages/thrift-server-core/src/transports/Transport.ts
+++ b/packages/thrift-server-core/src/transports/Transport.ts
@@ -1,30 +1,18 @@
 export interface ITransport {
-  commitPosition(): void
-  rollbackPosition(): void
+  open(): void
+  close(): void
 
   read(size: number): Promise<Buffer>
-  readByte(): Promise<number>
-  readBool(): Promise<boolean>
-  readI16(): Promise<number>
-  readI32(): Promise<number>
-  readDouble(): Promise<number>
-  readString(size: number): Promise<string>
 
-  write(buf: Buffer | string): void
-  writeByte(value: number): void
-  writeBool(value: boolean): void
-  writeI16(value: number): void
-  writeI32(value: number): void
-  writeDouble(value: number): void
-  writeString(value: string): void
+  // write(buf: Buffer | string): void
+  write(buf: Buffer): void
 
   flush(): void
 
+  // TODO: Below methods might not be needed
   consume(bytesConsumed: number): void
-
   borrow(): { buf: Buffer; readIndex: number; writeIndex: number; }
-
+  commitPosition(): void
+  rollbackPosition(): void
   isOpen(): boolean
-  open(): void
-  close(): void
 }

--- a/packages/thrift-server-core/src/transports/Transport.ts
+++ b/packages/thrift-server-core/src/transports/Transport.ts
@@ -1,0 +1,23 @@
+export interface ITransport {
+  commitPosition(): void
+  rollbackPosition(): void
+
+  read(size: number): Promise<Buffer>
+  readByte(): Promise<number>
+  readI16(): Promise<number>
+  readI32(): Promise<number>
+  readDouble(): Promise<number>
+  readString(size: number): Promise<string>
+
+  write(buf: Buffer | string): void
+
+  flush(): void
+
+  consume(bytesConsumed: number): void
+
+  borrow(): { buf: Buffer; readIndex: number; writeIndex: number; }
+
+  isOpen(): boolean
+  open(): void
+  close(): void
+}

--- a/packages/thrift-server-core/src/transports/Transport.ts
+++ b/packages/thrift-server-core/src/transports/Transport.ts
@@ -11,6 +11,12 @@ export interface ITransport {
   readString(size: number): Promise<string>
 
   write(buf: Buffer | string): void
+  writeByte(value: number): void
+  writeBool(value: boolean): void
+  writeI16(value: number): void
+  writeI32(value: number): void
+  writeDouble(value: number): void
+  writeString(value: string): void
 
   flush(): void
 

--- a/packages/thrift-server-core/src/transports/Transport.ts
+++ b/packages/thrift-server-core/src/transports/Transport.ts
@@ -10,9 +10,5 @@ export interface ITransport {
   flush(): void
 
   // TODO: Below methods might not be needed
-  consume(bytesConsumed: number): void
-  borrow(): { buf: Buffer; readIndex: number; writeIndex: number; }
-  commitPosition(): void
-  rollbackPosition(): void
   isOpen(): boolean
 }

--- a/packages/thrift-server-express/package.json
+++ b/packages/thrift-server-express/package.json
@@ -38,8 +38,9 @@
     "tslint-eslint-rules": "^4.1.1"
   },
   "dependencies": {
-    "typescript": "^2.4.2",
-    "thrift-server-core": "*"
+    "duplexify": "^3.5.1",
+    "thrift-server-core": "*",
+    "typescript": "^2.4.2"
   },
   "typings": "dist/index.d.ts",
   "typescript": {

--- a/packages/thrift-server-express/src/index.ts
+++ b/packages/thrift-server-express/src/index.ts
@@ -46,7 +46,7 @@ export function thriftExpress(Service, handlers, options: IOptions = {} as any) 
 
     try {
       const result = await process(service, stream, Transport, Protocol)
-      res.status(200).end(result)
+      res.status(200).end()
     } catch (err) {
       next(err)
     }

--- a/packages/thrift-server-express/src/index.ts
+++ b/packages/thrift-server-express/src/index.ts
@@ -9,6 +9,8 @@ import {
   supportedTransports,
 } from 'thrift-server-core'
 
+import duplexify = require('duplexify')
+
 // TODO: Can these be typed to specific strings?
 export interface IOptions {
   transport?: string
@@ -40,8 +42,10 @@ export function thriftExpress(Service, handlers, options: IOptions = {} as any) 
       return res.status(403).send('Method must be POST')
     }
 
+    const stream = duplexify(res, req)
+
     try {
-      const result = await process(service, req, Transport, Protocol)
+      const result = await process(service, stream, Transport, Protocol)
       res.status(200).end(result)
     } catch (err) {
       next(err)

--- a/packages/thrift-server-express/src/index.ts
+++ b/packages/thrift-server-express/src/index.ts
@@ -41,7 +41,7 @@ export function thriftExpress(Service, handlers, options: IOptions = {} as any) 
     }
 
     try {
-      const result = await process(service, req.body, Transport, Protocol)
+      const result = await process(service, req, Transport, Protocol)
       res.status(200).end(result)
     } catch (err) {
       next(err)


### PR DESCRIPTION
This should supersede #7 and #8 (I believe it includes both).

This is the work done around making a generic Processor for the server (#7) and rewrite of the Transports and Protocols (#8).  This PR continues upon the rewrite by adding making the Transports accept a Duplex Stream and making everything async.  I got this code working using my tutorial repo at https://github.com/phated/thrift-tutorial/pull/1 with the changes therein to the generated code.

@kevinbgreene @ian-harshman-ck Please review this and https://github.com/phated/thrift-tutorial/pull/1 for our call tomorrow.