### PR TITLE
Update README's and package.json's to be consistent with current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 Thrift core library in TypeScript
 
 Thrift Server is a collection of libraries that allow you to build Thrift servers and clients using familiar open source frameworks. Usually, you can easily set up your Thrift server or client as a plugin or middleware to a framework you are already using.
+
+## Contributing
+
+For more information about contributing new features and bug fixes, see our [Contribution Guidelines](https://github.com/creditkarma/CONTRIBUTING.md).
+External contributors must sign Contributor License Agreement (CLA)
+
+## License
+
+This project is licensed under [Apache License Version 2.0](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,37 +1,5 @@
-# thrift-ts-core
+# Thrift Server
+
 Thrift core library in TypeScript
 
-### Installation
-
-```sh
-npm i --save @creditkarma/thrift-ts-core
-```
-
-## Server API
-
-```typescript
-import { createServer, http } from '@creditkarma/thrift-ts-core'
-
-const handler = {
-  get: (request: RecommendationsRequest) => {
-    // Your service implementation
-  }
-};
-const server = createServer('recommendation-system')
-                // `http` will expose a `.server` interface for servers
-                .network(http, { port: 8080 })
-                .services('/', RecommendationSystemService, handler)
-
-// WIP
-server.start((port) => console.log(`Server listening on port ${port}`);)
-```
-
-## Client API
-
-```typescript
-import { createClient, http } from '@creditkarma/thrift-ts-core'
-
-const client = createClient('thrift-benchmark-proxy', EchoReportService)
-                // `http` will also expose a `.client` interface for clients
-                .network(http, { host: 'localhost', port: 8080 })
-```
+Thrift Server is a collection of libraries that allow you to build Thrift servers and clients using familiar open source frameworks. Usually, you can easily set up your Thrift server or client as a plugin or middleware to a framework you are already using.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   ],
   "author": "Credit Karma",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/creditkarma/thrift-server"
+  },
   "devDependencies": {
     "@types/code": "^4.0.3",
     "@types/debug": "0.0.30",

--- a/packages/thrift-server-core/README.md
+++ b/packages/thrift-server-core/README.md
@@ -1,0 +1,3 @@
+# Thrift Server Core
+
+Base package for the other Thrift libraries. This will usually not be used directly.

--- a/packages/thrift-server-core/README.md
+++ b/packages/thrift-server-core/README.md
@@ -1,3 +1,12 @@
 # Thrift Server Core
 
 Base package for the other Thrift libraries. This will usually not be used directly.
+
+## Contributing
+
+For more information about contributing new features and bug fixes, see our [Contribution Guidelines](https://github.com/creditkarma/CONTRIBUTING.md).
+External contributors must sign Contributor License Agreement (CLA)
+
+## License
+
+This project is licensed under [Apache License Version 2.0](./LICENSE)

--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -26,6 +26,10 @@
   ],
   "author": "Credit Karma",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/creditkarma/thrift-server/tree/master/packages/thrift-server-core"
+  },
   "devDependencies": {
     "@types/code": "^4.0.3",
     "@types/debug": "0.0.30",

--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "description": "Thrift core library in TypeScript",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "scripts": {
     "build": "npm run clean && npm run lint && npm run compile",
     "compile": "tsc",
@@ -40,9 +44,5 @@
   "dependencies": {
     "thrift": "^0.10.0",
     "typescript": "^2.4.2"
-  },
-  "typings": "dist/index.d.ts",
-  "typescript": {
-    "definition": "dist/index.d.ts"
   }
 }

--- a/packages/thrift-server-core/src/index.ts
+++ b/packages/thrift-server-core/src/index.ts
@@ -1,10 +1,12 @@
-import TBufferedTransport = require('thrift/lib/nodejs/lib/thrift/buffered_transport')
-import TFramedTransport = require('thrift/lib/nodejs/lib/thrift/framed_transport')
-import InputBufferUnderrunError = require('thrift/lib/nodejs/lib/thrift/input_buffer_underrun_error')
+import {
+  TBinaryProtocol,
+  TBufferedTransport,
+  TFramedTransport,
+  TCompactProtocol,
+  TJSONProtocol,
+} from 'thrift'
 
-import TBinaryProtocol = require('thrift/lib/nodejs/lib/thrift/binary_protocol')
-import TCompactProtocol = require('thrift/lib/nodejs/lib/thrift/compact_protocol')
-import TJSONProtocol = require('thrift/lib/nodejs/lib/thrift/json_protocol')
+const InputBufferUnderrunError: any = require('thrift/lib/nodejs/lib/thrift/input_buffer_underrun_error')
 
 const transports = {
   buffered: TBufferedTransport,

--- a/packages/thrift-server-express/README.md
+++ b/packages/thrift-server-express/README.md
@@ -1,0 +1,3 @@
+# Thrift Server Express
+
+Express middleware for processing Thrift requests.

--- a/packages/thrift-server-express/README.md
+++ b/packages/thrift-server-express/README.md
@@ -1,3 +1,12 @@
 # Thrift Server Express
 
 Express middleware for processing Thrift requests.
+
+## Contributing
+
+For more information about contributing new features and bug fixes, see our [Contribution Guidelines](https://github.com/creditkarma/CONTRIBUTING.md).
+External contributors must sign Contributor License Agreement (CLA)
+
+## License
+
+This project is licensed under [Apache License Version 2.0](./LICENSE)

--- a/packages/thrift-server-express/package.json
+++ b/packages/thrift-server-express/package.json
@@ -26,6 +26,10 @@
   ],
   "author": "Credit Karma",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/creditkarma/thrift-server/tree/master/packages/thrift-server-express"
+  },
   "devDependencies": {
     "@types/code": "^4.0.3",
     "@types/debug": "0.0.30",

--- a/packages/thrift-server-express/package.json
+++ b/packages/thrift-server-express/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "description": "Thrift core library in TypeScript",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
   "scripts": {
     "build": "npm run clean && npm run lint && npm run compile",
     "compile": "tsc",
@@ -40,9 +44,5 @@
   "dependencies": {
     "typescript": "^2.4.2",
     "thrift-server-core": "*"
-  },
-  "typings": "dist/index.d.ts",
-  "typescript": {
-    "definition": "dist/index.d.ts"
   }
 }

--- a/packages/thrift-server-express/tslint.json
+++ b/packages/thrift-server-express/tslint.json
@@ -1,7 +1,6 @@
 {
 	"extends": "tslint:recommended",
 	"rules": {
-		"use-strict": true,
 		"no-console": false,
     "no-var-requires": false,
     "semicolon": [

--- a/packages/thrift-server-hapi/README.md
+++ b/packages/thrift-server-hapi/README.md
@@ -1,0 +1,91 @@
+# Thrift Server Hapi
+
+Hapi plugin for processing Thrift requests.
+
+## Usage
+
+The easiest way to get started is to generate your thrift services using @creditkarma/thrift-typescript.
+
+### Install
+
+```sh
+npm install --save hapi
+npm install --save thrift
+npm install --save @creditkarma/thrift-server-hapi
+```
+
+### Register
+
+To get things working you need to register the ThriftPlugin and define handlers for your service methods.
+
+```typescript
+import * as Hapi from 'hapi'
+import * as Thrift from 'thrift'
+import { ThriftPlugin } from '@creditkarma/thrift-server-hapi'
+import { UserService } from './codegen/user_service'
+
+const server = new Hapi.Server({ debug: { request: [ 'error' ] } })
+
+/**
+ * Register the thrift plugin.
+ *
+ * This will allow us to define Hapi routes for our thrift service(s).
+ * They behave like any other HTTP route handler, so you can mix and match
+ * thrift / REST endpoints on the same server instance.
+ */
+server.register(ThriftPlugin, err => {
+    if (err) {
+        throw err
+    }
+})
+
+/**
+ * Implementation of our thrift service.
+ *
+ * Notice the second parameter, "context" - this is the Hapi request object,
+ * passed along to our service by the Hapi thrift plugin. Thus, you have access to
+ * all HTTP request data from within your service implementation.
+ */
+const impl = new UserService.Processor({
+    getUser: (request: RecommendationsRequest, context: Hapi.Request) => {
+        const userId = request.userId
+
+        if (userId.toNumber() <= 0) {
+            throw new Error('User ID must be greater than zero')
+        }
+
+        return getUserForId(userId)
+    },
+})
+
+/**
+ * Route to our thrift service.
+ *
+ * Payload parsing is disabled - the thrift plugin parses the raw request
+ * using whichever protocol is configured (binary, compact, json...)
+ */
+server.route({
+    method: 'POST',
+    path: '/',
+    handler: {
+        thrift: {
+            service: impl,
+        },
+    },
+    config: {
+        payload: {
+            parse: false,
+        },
+    },
+})
+
+/**
+ * Start your hapi server
+ */
+server.start((err) => {
+    if (err) {
+        throw err
+    }
+    server.log('info', `Server running on port ${port}`)
+})
+```

--- a/packages/thrift-server-hapi/README.md
+++ b/packages/thrift-server-hapi/README.md
@@ -89,3 +89,12 @@ server.start((err) => {
     server.log('info', `Server running on port ${port}`)
 })
 ```
+
+## Contributing
+
+For more information about contributing new features and bug fixes, see our [Contribution Guidelines](https://github.com/creditkarma/CONTRIBUTING.md).
+External contributors must sign Contributor License Agreement (CLA)
+
+## License
+
+This project is licensed under [Apache License Version 2.0](./LICENSE)

--- a/packages/thrift-server-hapi/package.json
+++ b/packages/thrift-server-hapi/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "description": "A Hapi server plugin for the Apache Thrift protocol",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "npm run clean && npm run lint && tsc",
     "clean": "rm -rf ./dist",
@@ -14,8 +18,8 @@
     "test:only": "lab -l -S ./dist/test",
     "lint": "tslint --fix './src/**/*.ts'"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Credit Karma",
+  "license": "Apache-2.0",
   "dependencies": {
     "thrift": "^0.10.0"
   },
@@ -28,6 +32,5 @@
     "tslint-eslint-rules": "^4.1.1",
     "typescript": "^2.4.2",
     "watch": "^1.0.2"
-  },
-  "types": "dist/index.d.ts"
+  }
 }

--- a/packages/thrift-server-hapi/package.json
+++ b/packages/thrift-server-hapi/package.json
@@ -20,6 +20,10 @@
   },
   "author": "Credit Karma",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/creditkarma/thrift-server/tree/master/packages/thrift-server-hapi"
+  },
   "dependencies": {
     "thrift": "^0.10.0"
   },


### PR DESCRIPTION
Our READMEs hadn't been updated to represent what was going on with project. Showed the old (theoretical) APIs, old name (thrift-ts-core) and package.json's weren't consistent.