### PR TITLE
Have thrift-server-hapi pull from core

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "updated": "lerna updated",
     "postinstall": "lerna bootstrap",
     "prebootstrap": "npm install",
+    "pretest": "lerna exec -- npm run build",
     "test": "lerna exec -- npm run test",
     "test-integration": "lerna run -- test-integration"
   },

--- a/packages/thrift-client/src/tests/index.spec.ts
+++ b/packages/thrift-client/src/tests/index.spec.ts
@@ -28,7 +28,7 @@ const it = lab.it
 const before = lab.before
 const after = lab.after
 
-describe('Thrift Server Hapi', () => {
+describe('Thrift Client', () => {
   let server: any
   let connection: HttpConnection<Calculator.Client>
   let client: Calculator.Client

--- a/packages/thrift-client/tsconfig.json
+++ b/packages/thrift-client/tsconfig.json
@@ -15,16 +15,11 @@
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": true,
     "pretty": true,
-    "removeComments": true,
-    "types": [
-      "@types/node",
-      "@types/express",
-      "@types/request",
-      "@types/thrift"
-    ]
+    "removeComments": true
   },
   "exclude": [
     "node_modules",
+    "dist",
     "example"
   ]
 }

--- a/packages/thrift-server-core/package.json
+++ b/packages/thrift-server-core/package.json
@@ -30,6 +30,10 @@
     "type": "git",
     "url": "https://github.com/creditkarma/thrift-server/tree/master/packages/thrift-server-core"
   },
+  "dependencies": {
+    "thrift": "^0.10.0",
+    "typescript": "^2.5.3"
+  },
   "devDependencies": {
     "@types/code": "^4.0.3",
     "@types/debug": "0.0.30",
@@ -45,9 +49,5 @@
     "rimraf": "^2.5.4",
     "tslint": "^5.6.0",
     "tslint-eslint-rules": "^4.1.1"
-  },
-  "dependencies": {
-    "thrift": "^0.10.0",
-    "typescript": "^2.5.3"
   }
 }

--- a/packages/thrift-server-core/src/tests/index.spec.ts
+++ b/packages/thrift-server-core/src/tests/index.spec.ts
@@ -6,11 +6,6 @@ export const lab = Lab.script()
 const describe = lab.describe
 const it = lab.it
 
-const config = {
-  hostName: 'localhost',
-  port: 8080,
-}
-
 describe('Thrift Server Core', () => {
 
     it('should true equal true', (done: any) => {

--- a/packages/thrift-server-core/tsconfig.json
+++ b/packages/thrift-server-core/tsconfig.json
@@ -7,13 +7,15 @@
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist",
+    "noEmitOnError": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": true,
     "pretty": true,
-    "removeComments": true,
-    "types": [
-      "@types/node",
-      "@types/code"
-    ]
+    "removeComments": true
   },
   "exclude": [
     "node_modules",

--- a/packages/thrift-server-core/tsconfig.json
+++ b/packages/thrift-server-core/tsconfig.json
@@ -13,7 +13,6 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
-    "allowUnreachableCode": true,
     "pretty": true,
     "removeComments": true
   },

--- a/packages/thrift-server-express/package.json
+++ b/packages/thrift-server-express/package.json
@@ -31,6 +31,11 @@
     "type": "git",
     "url": "https://github.com/creditkarma/thrift-server/tree/master/packages/thrift-server-express"
   },
+  "dependencies": {
+    "@creditkarma/thrift-server-core": "0.0.*",
+    "thrift": "^0.10.0",
+    "typescript": "^2.5.3"
+  },
   "devDependencies": {
     "@creditkarma/thrift-typescript": "^0.0.7",
     "@types/body-parser": "^1.16.5",
@@ -49,10 +54,5 @@
     "rimraf": "^2.5.4",
     "tslint": "^5.6.0",
     "tslint-eslint-rules": "^4.1.1"
-  },
-  "dependencies": {
-    "@creditkarma/thrift-server-core": "^0.0.1",
-    "thrift": "^0.10.0",
-    "typescript": "^2.5.3"
   }
 }

--- a/packages/thrift-server-express/src/main/index.ts
+++ b/packages/thrift-server-express/src/main/index.ts
@@ -27,7 +27,7 @@ export interface IOptions {
 export function thriftExpress<TProcessor, THandler>(
   Service: TProcessorConstructor<TProcessor, THandler>,
   handlers: THandler,
-  options: IOptions = {} as any) {
+  options: IOptions = {}): express.RequestHandler {
 
   const transport = options.transport
   if (transport && !isTransportSupported(transport)) {
@@ -46,10 +46,13 @@ export function thriftExpress<TProcessor, THandler>(
   // TODO: Should this be constructed once per plugin or once per request?
   const service: TProcessor = getService(Service, handlers)
 
-  async function handler(req: express.Request, res: express.Response, next: express.NextFunction) {
+  async function handler(
+    request: express.Request,
+    response: express.Response,
+    next: express.NextFunction): Promise<void> {
     try {
-      const result = await process(service, req.body, Transport, Protocol)
-      res.status(200).end(result)
+      const result = await process(service, request.body, Transport, Protocol, request)
+      response.status(200).end(result)
     } catch (err) {
       next(err)
     }

--- a/packages/thrift-server-express/tsconfig.json
+++ b/packages/thrift-server-express/tsconfig.json
@@ -7,20 +7,15 @@
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist",
+    "noEmitOnError": true,
+    "strictNullChecks": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": true,
     "pretty": true,
-    "removeComments": true,
-    "types": [
-      "@types/node",
-      "@types/code",
-      "@types/express",
-      "@types/thrift",
-      "@types/body-parser"
-    ]
+    "removeComments": true
   },
   "exclude": [
     "node_modules",

--- a/packages/thrift-server-express/tsconfig.json
+++ b/packages/thrift-server-express/tsconfig.json
@@ -13,7 +13,6 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
-    "allowUnreachableCode": true,
     "pretty": true,
     "removeComments": true
   },

--- a/packages/thrift-server-hapi/package.json
+++ b/packages/thrift-server-hapi/package.json
@@ -28,6 +28,7 @@
     "url": "https://github.com/creditkarma/thrift-server/tree/master/packages/thrift-server-hapi"
   },
   "dependencies": {
+    "@creditkarma/thrift-server-core": "0.0.*",
     "thrift": "^0.10.0"
   },
   "peerDependencies": {

--- a/packages/thrift-server-hapi/tsconfig.json
+++ b/packages/thrift-server-hapi/tsconfig.json
@@ -13,7 +13,6 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
-    "allowUnreachableCode": true,
     "pretty": true,
     "removeComments": true
   },

--- a/packages/thrift-server-hapi/tsconfig.json
+++ b/packages/thrift-server-hapi/tsconfig.json
@@ -7,18 +7,15 @@
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist",
+    "noEmitOnError": true,
+    "strictNullChecks": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": true,
     "pretty": true,
-    "removeComments": true,
-    "types": [
-      "@types/node",
-      "@types/code",
-      "@types/thrift"
-    ]
+    "removeComments": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
In preparation of publishing all packages.

There is an issue with the way lerna symlinks packages when using the "types" property in tsconfig. We've been doing this:
```
types: [
  "@types/..."
]
```
When running tests with lerna this could cause duplicate type definition errors. TypeScript includes everything in @types be default so I removed this from tsconfig. It gets rid of the symlink issues with lerna.