### PR TITLE
Add JSON protocol

### DIFF
--- a/packages/thrift-server-core/src/main/parse_json.ts
+++ b/packages/thrift-server-core/src/main/parse_json.ts
@@ -1,0 +1,257 @@
+/**
+ * This implementation is largely taken from the Apache project and reimplemented in TypeScript.
+ *
+ * The orginal project can be found here:
+ * https://raw.githubusercontent.com/apache/thrift/master/lib/nodejs/lib/thrift/json_parse.js
+ */
+
+import { Int64 } from './Int64'
+
+type JsonValue = {} | Array<any> | string | number | boolean | null | undefined
+
+class JsonParser {
+    private at = 0
+    private ch = ''
+    private escapee: Record<string, string> = {
+        '"': '"',
+        '\\': '\\',
+        '/': '/',
+        'b': '\b',
+        'f': '\f',
+        'n': '\n',
+        'r': '\r',
+        't': '\t',
+    }
+    private text = ''
+
+    constructor(source: string) {
+        this.text = source
+        this.at = 0
+        this.ch = ' '
+    }
+
+    public parse(): any {
+        const result = this.value()
+        this.white()
+        if (this.getCh()) {
+            throw new SyntaxError('Syntax error')
+        }
+
+        return result
+    }
+
+    private array() {
+        // Parse an array value.
+        const array: Array<any> = []
+
+        if (this.getCh() === '[') {
+            this.next('[')
+            this.white()
+            if (this.getCh() === ']') {
+                this.next(']')
+                return array // empty array
+            }
+            while (this.getCh()) {
+                array.push(this.value())
+                this.white()
+                if (this.getCh() === ']') {
+                    this.next(']')
+                    return array
+                }
+                this.next(',')
+                this.white()
+            }
+        }
+        throw new SyntaxError('Bad array')
+    }
+
+    private object() {
+        // Parse an object value.
+
+        let key: string | undefined = ''
+        const object: Record<string, JsonValue> = {}
+
+        if (this.getCh() === '{') {
+            this.next('{')
+            this.white()
+            if (this.getCh() === '}') {
+                this.next('}')
+                return object // empty object
+            }
+            while (this.getCh()) {
+                key = this.string()
+                this.white()
+                this.next(':')
+                if (Object.hasOwnProperty.call(object, key)) {
+                    throw new SyntaxError('Duplicate key "' + key + '"')
+                }
+                object[key] = this.value()
+                this.white()
+                if (this.getCh() === '}') {
+                    this.next('}')
+                    return object
+                }
+                this.next(',')
+                this.white()
+            }
+        }
+        throw new SyntaxError('Bad object')
+    }
+
+    private value(): JsonValue {
+        // Parse a JSON value. It could be an object, an array, a string, a number,
+        // or a word.
+
+        this.white()
+        switch (this.getCh()) {
+            case '{':
+                return this.object()
+            case '[':
+                return this.array()
+            case '"':
+                return this.string()
+            case '-':
+                return this.number()
+            default:
+                return this.getCh() >= '0' && this.getCh() <= '9'
+                    ? this.number()
+                    : this.word()
+        }
+    }
+
+    private next(c?: string) {
+        // If a c parameter is provided, verify that it matches the current character.
+        if (c && c !== this.getCh()) {
+            throw new SyntaxError("Expected '" + c + "' instead of '" + this.getCh() + "'")
+        }
+
+        // Get the next character. When there are no more characters,
+        // return the empty string.
+
+        this.ch = this.text.charAt(this.at)
+        this.at += 1
+        return this.ch
+    }
+
+    private getCh() {
+        return this.ch
+    }
+
+    private number() {
+        // Parse a number value.
+        let number = 0
+        let string = ''
+
+        if (this.getCh() === '-') {
+            string = '-'
+            this.next('-')
+        }
+        while (this.getCh() >= '0' && this.getCh() <= '9') {
+            string += this.getCh()
+            this.next()
+        }
+        if (this.getCh() === '.') {
+            string += '.'
+            while (this.next() && this.getCh() >= '0' && this.getCh() <= '9') {
+                string += this.getCh()
+            }
+        }
+        if (this.getCh() === 'e' || this.getCh() === 'E') {
+            string += this.getCh()
+            this.next()
+            if (this.getCh() === '-' || this.getCh() === '+') {
+                string += this.getCh()
+                this.next()
+            }
+            while (this.getCh() >= '0' && this.getCh() <= '9') {
+                string += this.getCh()
+                this.next()
+            }
+        }
+        number = +string
+        if (!isFinite(number)) {
+            throw new SyntaxError('Bad number')
+        } else if (number >= Int64.MAX_INT || number <= Int64.MIN_INT) {
+            // Return raw string for further process in JSONProtocol
+            return string
+        } else {
+            return number
+        }
+    }
+
+    private string(): string {
+        // Parse a string value.
+        let hex = 0
+        let i = 0
+        let string = ''
+        let uffff = 0
+
+        // When parsing for string values, we must look for " and \ characters.
+        if (this.getCh() === '"') {
+            while (this.next()) {
+                if (this.getCh() === '"') {
+                    this.next()
+                    return string
+                }
+                if (this.getCh() === '\\') {
+                    this.next()
+                    if (this.getCh() === 'u') {
+                        uffff = 0
+                        for (i = 0; i < 4; i += 1) {
+                            hex = parseInt(this.next(), 16)
+                            if (!isFinite(hex)) {
+                                break
+                            }
+                            uffff = uffff * 16 + hex
+                        }
+                        string += String.fromCharCode(uffff)
+                    } else if (typeof this.escapee[this.getCh()] === 'string') {
+                        string += this.escapee[this.getCh()]
+                    } else {
+                        break
+                    }
+                } else {
+                    string += this.getCh()
+                }
+            }
+        }
+        throw new SyntaxError('Bad string')
+    }
+
+    private white() {
+        // Skip whitespace.
+        while (this.getCh() && this.getCh() <= ' ') {
+            this.next()
+        }
+    }
+
+    private word() {
+        // true, false, or null.
+        switch (this.getCh()) {
+            case 't':
+                this.next('t')
+                this.next('r')
+                this.next('u')
+                this.next('e')
+                return true
+            case 'f':
+                this.next('f')
+                this.next('a')
+                this.next('l')
+                this.next('s')
+                this.next('e')
+                return false
+            case 'n':
+                this.next('n')
+                this.next('u')
+                this.next('l')
+                this.next('l')
+                return null
+        }
+        throw new SyntaxError("Unexpected '" + this.getCh() + "'")
+    }
+}
+
+export function parseJson(source: string) {
+    return new JsonParser(source).parse()
+}

--- a/packages/thrift-server-core/src/main/protocols/JSONProtocol.ts
+++ b/packages/thrift-server-core/src/main/protocols/JSONProtocol.ts
@@ -1,0 +1,623 @@
+/**
+ * This implementation is largely taken from the Apache project and reimplemented in TypeScript.
+ *
+ * The orginal project can be found here:
+ * https://github.com/apache/thrift/blob/master/lib/js/src/thrift.js
+ */
+import { TProtocolException, TProtocolExceptionType } from '../errors'
+
+import { TTransport } from '../transports'
+
+import {
+    Int64,
+    IThriftField,
+    IThriftList,
+    IThriftMap,
+    IThriftMessage,
+    IThriftSet,
+    IThriftStruct,
+    MessageType,
+    TType,
+} from '../types'
+
+import { parseJson } from '../parse_json'
+import { TProtocol } from './TProtocol'
+
+export class JSONProtocol extends TProtocol {
+    private static readonly version = 1
+
+    private static readonly rType: { [K: string]: TType } = {
+        tf: TType.BOOL,
+        i8: TType.BYTE,
+        i16: TType.I16,
+        i32: TType.I32,
+        i64: TType.I64,
+        dbl: TType.DOUBLE,
+        rec: TType.STRUCT,
+        str: TType.STRING,
+        map: TType.MAP,
+        lst: TType.LIST,
+        set: TType.SET,
+    }
+    private tstack: Array<any> = []
+    private tpos: Array<number> = []
+
+    private rstack: Array<any> = []
+    private rpos: Array<number> = []
+
+    constructor(trans: TTransport) {
+        super(trans)
+        this.tstack = []
+        this.tpos = []
+    }
+
+    public writeMessageBegin(name: string, type: MessageType, id: number) {
+        this.tstack = []
+        this.tpos = []
+
+        this.tstack.push([JSONProtocol.version, `"${name}"`, type, id])
+    }
+
+    public writeMessageEnd() {
+        const obj = this.tstack.pop()
+
+        const wobj = this.tstack.pop()
+        wobj.push(obj)
+
+        const wbuf = `[${wobj.join(',')}]`
+
+        this.transport.write(Buffer.from(wbuf))
+    }
+
+    public writeStructBegin(name: string) {
+        this.tpos.push(this.tstack.length)
+        this.tstack.push({})
+    }
+
+    public writeStructEnd() {
+        const p = this.tpos.pop()
+        if (p === undefined) {
+            return
+        }
+
+        const struct = this.tstack[p]
+        let str = '{'
+        let first = true
+        for (const key of Object.keys(struct)) {
+            if (first) {
+                first = false
+            } else {
+                str += ','
+            }
+
+            str += `${key}:${struct[key]}`
+        }
+
+        str += '}'
+        this.tstack[p] = str
+    }
+
+    public writeFieldBegin(name: string, type: TType, id: number) {
+        this.tpos.push(this.tstack.length)
+        this.tstack.push({
+            fieldId: `"${id}"`,
+            fieldType: this.getTypeName(type),
+        })
+    }
+
+    public writeFieldEnd() {
+        const value = this.tstack.pop()
+        const fieldInfo = this.tstack.pop()
+
+        this.tstack[this.tstack.length - 1][fieldInfo.fieldId] =
+            `{${fieldInfo.fieldType}:${value}}`
+        this.tpos.pop()
+    }
+
+    public writeFieldStop() {}
+
+    public writeMapBegin(keyType: TType, valType: TType, size: number) {
+        this.tpos.push(this.tstack.length)
+        this.tstack.push([
+            this.getTypeName(keyType),
+            this.getTypeName(valType),
+            0,
+        ])
+    }
+
+    public writeMapEnd() {
+        const p = this.tpos.pop()
+        if (p === undefined) {
+            return
+        }
+
+        if (p === this.tstack.length) {
+            return
+        }
+
+        if ((this.tstack.length - p - 1) % 2 !== 0) {
+            this.tstack.push('')
+        }
+
+        const size = (this.tstack.length - p - 1) / 2
+
+        this.tstack[p][this.tstack[p].length - 1] = size
+
+        let map = '}'
+        let first = true
+        while (this.tstack.length > p + 1) {
+            const v = this.tstack.pop()
+            let k = this.tstack.pop()
+            if (first) {
+                first = false
+            } else {
+                map = `,${map}`
+            }
+
+            if (!isNaN(k)) {
+                k = `"${k}"`
+            } // json "keys" need to be strings
+            map = `${k}:${v}${map}`
+        }
+        map = `{${map}`
+
+        this.tstack[p].push(map)
+        this.tstack[p] = `[${this.tstack[p].join(',')}]`
+    }
+
+    public writeListBegin(elemType: TType, size: number) {
+        this.tpos.push(this.tstack.length)
+        this.tstack.push([this.getTypeName(elemType), size])
+    }
+
+    public writeListEnd() {
+        const p = this.tpos.pop()
+        if (p === undefined) {
+            return
+        }
+
+        while (this.tstack.length > p + 1) {
+            const tmpVal = this.tstack[p + 1]
+            this.tstack.splice(p + 1, 1)
+            this.tstack[p].push(tmpVal)
+        }
+
+        this.tstack[p] = `[${this.tstack[p].join(',')}]`
+    }
+
+    public writeSetBegin(elemType: TType, size: number) {
+        this.tpos.push(this.tstack.length)
+        this.tstack.push([this.getTypeName(elemType), size])
+    }
+
+    public writeSetEnd() {
+        const p = this.tpos.pop()
+        if (p === undefined) {
+            return
+        }
+
+        while (this.tstack.length > p + 1) {
+            const tmpVal = this.tstack[p + 1]
+            this.tstack.splice(p + 1, 1)
+            this.tstack[p].push(tmpVal)
+        }
+
+        this.tstack[p] = `[${this.tstack[p].join(',')}]`
+    }
+
+    public writeBool(value: boolean) {
+        this.tstack.push(value ? 1 : 0)
+    }
+
+    public writeByte(i8: number) {
+        this.tstack.push(i8)
+    }
+
+    public writeI16(i16: number) {
+        this.tstack.push(i16)
+    }
+
+    public writeI32(i32: number) {
+        this.tstack.push(i32)
+    }
+
+    public writeI64(i64: number | Int64) {
+        if (i64 instanceof Int64) {
+            this.tstack.push(i64.toDecimalString())
+        } else {
+            this.tstack.push(i64)
+        }
+    }
+
+    public writeDouble(dbl: number) {
+        this.tstack.push(dbl)
+    }
+
+    public writeString(str: string | null) {
+        // We do not encode uri components for wire transfer:
+        if (str === null) {
+            this.tstack.push(null)
+        } else {
+            // concat may be slower than building a byte buffer
+            let escapedString = ''
+            for (let i = 0; i < str.length; i++) {
+                const ch = str.charAt(i) // a single double quote: "
+                if (ch === '"') {
+                    escapedString += '\\"' // write out as: \"
+                } else if (ch === '\\') {
+                    // a single backslash
+                    escapedString += '\\\\' // write out as double backslash
+                } else if (ch === '\b') {
+                    // a single backspace: invisible
+                    escapedString += '\\b' // write out as: \b"
+                } else if (ch === '\f') {
+                    // a single formfeed: invisible
+                    escapedString += '\\f' // write out as: \f"
+                } else if (ch === '\n') {
+                    // a single newline: invisible
+                    escapedString += '\\n' // write out as: \n"
+                } else if (ch === '\r') {
+                    // a single return: invisible
+                    escapedString += '\\r' // write out as: \r"
+                } else if (ch === '\t') {
+                    // a single tab: invisible
+                    escapedString += '\\t' // write out as: \t"
+                } else {
+                    escapedString += ch // Else it need not be escaped
+                }
+            }
+            this.tstack.push(`"${escapedString}"`)
+        }
+    }
+
+    public writeBinary(binary: string | Buffer) {
+        let str = ''
+        if (typeof binary === 'string') {
+            str = binary
+        } else if (binary instanceof Uint8Array) {
+            const arr = binary
+            for (const i of arr) {
+                str += String.fromCharCode(arr[i])
+            }
+        } else {
+            throw new TypeError('writeBinary only accepts String or Uint8Array.')
+        }
+        this.tstack.push(`"${Buffer.from(str).toString('base64')}"`)
+    }
+
+    public readMessageBegin(): IThriftMessage {
+        this.rstack = []
+        this.rpos = []
+
+        const robj = parseJson(this.transport.readAll())
+
+        const version = robj.shift()
+
+        if (version !== JSONProtocol.version) {
+            throw new Error(`Wrong thrift protocol version: ${version}`)
+        }
+
+        const r: IThriftMessage = {
+            fieldName: robj.shift(),
+            messageType: robj.shift(),
+            requestId: robj.shift(),
+        }
+
+        // get to the main obj
+        this.rstack.push(robj.shift())
+
+        return r
+    }
+
+    public readMessageEnd() {}
+
+    public readStructBegin() {
+        const r: IThriftStruct = {
+            fieldName: '',
+        }
+
+        // incase this is an array of structs
+        if (this.rstack[this.rstack.length - 1] instanceof Array) {
+            this.rstack.push(this.rstack[this.rstack.length - 1].shift())
+        }
+
+        return r
+    }
+
+    public readStructEnd() {
+        if (this.rstack[this.rstack.length - 2] instanceof Array) {
+            this.rstack.pop()
+        }
+    }
+
+    public readFieldBegin(): IThriftField {
+        let fid = -1
+        let ftype = TType.STOP
+
+        // get a fieldId
+        for (const f in this.rstack[this.rstack.length - 1]) {
+            if (f === null) {
+                continue
+            }
+
+            fid = parseInt(f, 10)
+            this.rpos.push(this.rstack.length)
+
+            const field = this.rstack[this.rstack.length - 1][fid]
+
+            // remove so we don't see it again
+            delete this.rstack[this.rstack.length - 1][fid]
+
+            this.rstack.push(field)
+
+            break
+        }
+
+        if (fid !== -1) {
+            // should only be 1 of these but this is the only
+            // way to match a key
+            for (const i in this.rstack[this.rstack.length - 1]) {
+                if (JSONProtocol.rType[i] === null) {
+                    continue
+                }
+
+                ftype = JSONProtocol.rType[i]
+                this.rstack[this.rstack.length - 1] = this.rstack[
+                    this.rstack.length - 1
+                ][i]
+            }
+        }
+
+        return {
+            fieldId: fid,
+            fieldName: '',
+            fieldType: ftype,
+        }
+    }
+
+    public readFieldEnd() {
+        const pos = this.rpos.pop()
+        if (pos === undefined) {
+            return
+        }
+
+        // get back to the right place in the stack
+        while (this.rstack.length > pos) {
+            this.rstack.pop()
+        }
+    }
+
+    public readMapBegin(): IThriftMap {
+        let map = this.rstack.pop()
+        let first = map.shift()
+        if (first instanceof Array) {
+            this.rstack.push(map)
+            map = first
+            first = map.shift()
+        }
+
+        const r: IThriftMap = {
+            keyType: JSONProtocol.rType[first],
+            valueType: JSONProtocol.rType[map.shift()],
+            size: map.shift(),
+        }
+
+        this.rpos.push(this.rstack.length)
+        this.rstack.push(map.shift())
+
+        return r
+    }
+
+    public readMapEnd() {
+        this.readFieldEnd()
+    }
+
+    public readListBegin(): IThriftList {
+        const list = this.rstack[this.rstack.length - 1]
+
+        const r: IThriftList = {
+            elementType: JSONProtocol.rType[list.shift()],
+            size: list.shift(),
+        }
+
+        this.rpos.push(this.rstack.length)
+        this.rstack.push(list.shift())
+
+        return r
+    }
+
+    public readListEnd() {
+        let pos = this.rpos.pop()
+        if (pos === undefined) {
+            return
+        }
+        pos = pos - 2
+        const st = this.rstack
+        st.pop()
+        if (st instanceof Array && st.length > pos && st[pos].length > 0) {
+            st.push(st[pos].shift())
+        }
+    }
+
+    public readSetBegin(): IThriftSet {
+        return this.readListBegin()
+    }
+
+    public readSetEnd() {
+        return this.readListEnd()
+    }
+
+    public readBool(): boolean {
+        const r = this.readValue()
+        if (r === null) {
+            return false
+        } else if (r === '1' || r === 1) {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    public readByte() {
+        return this.readI32()
+    }
+
+    public readI16(): number {
+        return this.readI32()
+    }
+
+    public readI32(): number {
+        return parseInt(this.readValue(), 10)
+    }
+
+    public readI64(): Int64 {
+        return Int64.fromDecimalString(`${this.readValue()}`)
+    }
+
+    public readDouble() {
+        return parseFloat(this.readValue())
+    }
+
+    public readBinary() {
+        return new Buffer(this.readValue(), 'base64')
+    }
+
+    public readString() {
+        return this.readValue()
+    }
+
+    public skip(type: TType) {
+        switch (type) {
+            case TType.STOP:
+                return null
+
+            case TType.BOOL:
+                return this.readBool()
+
+            case TType.BYTE:
+                return this.readByte()
+
+            case TType.I16:
+                return this.readI16()
+
+            case TType.I32:
+                return this.readI32()
+
+            case TType.I64:
+                return this.readI64()
+
+            case TType.DOUBLE:
+                return this.readDouble()
+
+            case TType.STRING:
+                return this.readString()
+
+            case TType.STRUCT:
+                this.readStructBegin()
+                while (true) {
+                    const struct = this.readFieldBegin()
+                    if (struct.fieldType === TType.STOP) {
+                        break
+                    }
+                    this.skip(struct.fieldType)
+                    this.readFieldEnd()
+                }
+                this.readStructEnd()
+                return null
+
+            case TType.MAP:
+                const map = this.readMapBegin()
+                for (let i = 0; i < map.size; i++) {
+                    if (i > 0) {
+                        if (
+                            this.rstack.length >
+                            this.rpos[this.rpos.length - 1] + 1
+                        ) {
+                            this.rstack.pop()
+                        }
+                    }
+                    this.skip(map.keyType)
+                    this.skip(map.keyType)
+                }
+                this.readMapEnd()
+                return null
+
+            case TType.SET:
+                const set = this.readSetBegin()
+                for (let i = 0; i < set.size; i++) {
+                    this.skip(set.elementType)
+                }
+                this.readSetEnd()
+                return null
+
+            case TType.LIST:
+                const list = this.readListBegin()
+                for (let i = 0; i < list.size; i++) {
+                    this.skip(list.elementType)
+                }
+                this.readListEnd()
+                return null
+
+            default:
+                throw new TProtocolException(TProtocolExceptionType.INVALID_DATA)
+        }
+    }
+
+    private readValue() {
+        const f = this.rstack[this.rstack.length - 1]
+
+        if (f instanceof Array) {
+            if (f.length === 0) {
+                return undefined
+            } else {
+                return f.shift()
+            }
+        } else if (f instanceof Object) {
+            for (const i in f) {
+                if (i === null) {
+                    continue
+                }
+                this.rstack.push(f[i])
+                delete f[i]
+
+                return i
+                break
+            }
+        } else {
+            this.rstack.pop()
+            return f
+        }
+    }
+
+    private getTypeName(type: TType) {
+        switch (type) {
+            case TType.BOOL:
+                return '"tf"'
+            case TType.BYTE:
+                return '"i8"'
+            case TType.I16:
+                return '"i16"'
+            case TType.I32:
+                return '"i32"'
+            case TType.I64:
+                return '"i64"'
+            case TType.DOUBLE:
+                return '"dbl"'
+            case TType.STRUCT:
+                return '"rec"'
+            case TType.STRING:
+                return '"str"'
+            case TType.MAP:
+                return '"map"'
+            case TType.LIST:
+                return '"lst"'
+            case TType.SET:
+                return '"set"'
+            default:
+                throw new TProtocolException(
+                    TProtocolExceptionType.NOT_IMPLEMENTED,
+                    `Unrecognized type ${type}`,
+                )
+        }
+    }
+}

--- a/packages/thrift-server-core/src/main/protocols/index.ts
+++ b/packages/thrift-server-core/src/main/protocols/index.ts
@@ -1,4 +1,4 @@
 export * from './BinaryProtocol'
 export * from './CompactProtocol'
-// export * from './JSONProtocol'
+export * from './JSONProtocol'
 export * from './TProtocol'

--- a/packages/thrift-server-core/src/main/transports/BufferedTransport.ts
+++ b/packages/thrift-server-core/src/main/transports/BufferedTransport.ts
@@ -114,6 +114,10 @@ export class BufferedTransport extends TTransport {
         return str
     }
 
+    public readAll(): string {
+        return this.readString(this.buffer.length - this.readCursor)
+    }
+
     public consume(len: number): void {
         this.readCursor += len
     }

--- a/packages/thrift-server-core/src/main/transports/TTransport.ts
+++ b/packages/thrift-server-core/src/main/transports/TTransport.ts
@@ -31,6 +31,7 @@ export abstract class TTransport {
     public abstract readI32(): number
     public abstract readDouble(): number
     public abstract readString(len: number): string
+    public abstract readAll(): string
 
     /**
      * Writes buffer to the output

--- a/packages/thrift-server-core/src/main/types.ts
+++ b/packages/thrift-server-core/src/main/types.ts
@@ -146,7 +146,7 @@ export interface IProcessorConstructor<TProcessor, THandler> {
 }
 
 export type ProtocolType =
-    'binary' | 'compact' // | 'json'
+    'binary' | 'compact' | 'json'
 
 export type TransportType =
     'buffered' // | 'framed'

--- a/packages/thrift-server-core/src/main/utils.ts
+++ b/packages/thrift-server-core/src/main/utils.ts
@@ -1,6 +1,6 @@
 import * as url from 'url'
 import * as logger from './logger'
-import { BinaryProtocol, CompactProtocol, TProtocol } from './protocols'
+import { BinaryProtocol, CompactProtocol, JSONProtocol, TProtocol } from './protocols'
 import { BufferedTransport, TTransport } from './transports'
 
 import {
@@ -39,7 +39,7 @@ export const supportedTransports: Array<string> = Object.keys(transports)
 const protocols: IProtocolMap = {
     binary: BinaryProtocol,
     compact: CompactProtocol,
-    // json: JSONProtocol,
+    json: JSONProtocol,
 }
 
 export const supportedProtocols: Array<string> = Object.keys(protocols)

--- a/packages/thrift-server-core/src/tests/unit/JSONProtocol.spec.ts
+++ b/packages/thrift-server-core/src/tests/unit/JSONProtocol.spec.ts
@@ -1,0 +1,788 @@
+import { expect } from 'code'
+import * as Lab from 'lab'
+
+import {
+    BufferedTransport,
+    Int64,
+    JSONProtocol,
+    MessageType,
+    TType,
+} from '../../main'
+
+export const lab = Lab.script()
+
+const describe = lab.describe
+const it = lab.it
+
+describe('JSONProtocol', () => {
+    describe('calls', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getMessage', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+
+            protocol.writeStructBegin('request')
+            protocol.writeStructEnd()
+
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getMessage",1,1,{"1":{"rec":{}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(`[1,"getMessage",1,1,{"1":{"rec":{}}}]`)
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            expect(protocol.readMessageBegin()).to.equal({
+                fieldName: 'getMessage',
+                messageType: MessageType.CALL,
+                requestId: 1,
+            })
+
+            protocol.readStructBegin()
+            protocol.readStructEnd()
+
+            expect(protocol.readMessageEnd()).to.be.undefined()
+        })
+    })
+
+    describe('bools', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getBool', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('t', TType.BOOL, 1)
+            protocol.writeBool(true)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('f', TType.BOOL, 2)
+            protocol.writeBool(false)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getBool",1,1,{"1":{"rec":{"1":{"tf":1},"2":{"tf":0}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getBool",1,1,{"1":{"rec":{"1":{"tf":1},"2":{"tf":0}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readBool()).to.equal(true)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readBool()).to.equal(false)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('bytes', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getByte', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('lower', TType.BYTE, 1)
+            protocol.writeByte(-128)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('mid', TType.BYTE, 2)
+            protocol.writeByte(0)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('upper', TType.BYTE, 3)
+            protocol.writeByte(127)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getByte",1,1,{"1":{"rec":{"1":{"i8":-128},"2":{"i8":0},"3":{"i8":127}}}}]`,
+            )
+        })
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getByte",1,1,{"1":{"rec":{"1":{"i8":-128},"2":{"i8":0},"3":{"i8":127}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readByte()).to.equal(-128)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readByte()).to.equal(0)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readByte()).to.equal(127)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('i16s', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getI16', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('lower', TType.I16, 1)
+            protocol.writeI16(-32768)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('mid', TType.I16, 2)
+            protocol.writeI16(0)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('upper', TType.I16, 3)
+            protocol.writeI16(32767)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getI16",1,1,{"1":{"rec":{"1":{"i16":-32768},"2":{"i16":0},"3":{"i16":32767}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getI16",1,1,{"1":{"rec":{"1":{"i16":-32768},"2":{"i16":0},"3":{"i16":32767}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI16()).to.equal(-32768)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI16()).to.equal(0)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI16()).to.equal(32767)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('i32s', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getI32', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('lower', TType.I32, 1)
+            protocol.writeI32(-2147483648)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('mid', TType.I32, 2)
+            protocol.writeI32(0)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('upper', TType.I32, 3)
+            protocol.writeI32(2147483647)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getI32",1,1,{"1":{"rec":{"1":{"i32":-2147483648},"2":{"i32":0},"3":{"i32":2147483647}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getI32",1,1,{"1":{"rec":{"1":{"i32":-2147483648},"2":{"i32":0},"3":{"i32":2147483647}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI32()).to.equal(-2147483648)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI32()).to.equal(0)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI32()).to.equal(2147483647)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('i64s', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getI64', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('lower', TType.I64, 1)
+            protocol.writeI64(Int64.fromDecimalString('-9223372036854775808'))
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('mid', TType.I64, 2)
+            protocol.writeI64(0)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('upper', TType.I64, 3)
+            protocol.writeI64(Int64.fromDecimalString('9223372036854775807'))
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI64()).to.equal(
+                Int64.fromDecimalString('-9223372036854775808'),
+            )
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI64()).to.equal(Int64.fromDecimalString('0'))
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readI64()).to.equal(
+                Int64.fromDecimalString('9223372036854775807'),
+            )
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('doubles', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('lower', TType.DOUBLE, 1)
+            protocol.writeDouble(4.94e-322)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('mid', TType.DOUBLE, 2)
+            protocol.writeDouble(0)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('upper', TType.DOUBLE, 3)
+            protocol.writeDouble(1.7976931348623157e+308)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getDouble",1,1,{"1":{"rec":{"1":{"dbl":4.94e-322},"2":{"dbl":0},"3":{"dbl":1.7976931348623157e+308}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getDouble",1,1,{"1":{"rec":{"1":{"dbl":4.94e-322},"2":{"dbl":0},"3":{"dbl":1.7976931348623157e+308}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readDouble()).to.equal(4.94e-322)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readDouble()).to.equal(0)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readDouble()).to.equal(1.7976931348623157e308)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('strings', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getString', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('empty', TType.STRING, 1)
+            protocol.writeString('')
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('foo', TType.STRING, 2)
+            protocol.writeString('foo')
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('bar', TType.STRING, 3)
+            protocol.writeString('bar')
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getString",1,1,{"1":{"rec":{"1":{"str":""},"2":{"str":"foo"},"3":{"str":"bar"}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getString",1,1,{"1":{"rec":{"1":{"str":""},"2":{"str":"foo"},"3":{"str":"bar"}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readString()).to.equal('')
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readString()).to.equal('foo')
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readString()).to.equal('bar')
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('lists', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getList', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('empty', TType.LIST, 1)
+            protocol.writeListBegin(TType.BOOL, 2)
+            protocol.writeBool(true)
+            protocol.writeBool(false)
+            protocol.writeListEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('foo', TType.LIST, 2)
+            protocol.writeListBegin(TType.I32, 3)
+            protocol.writeI32(-128)
+            protocol.writeI32(0)
+            protocol.writeI32(127)
+            protocol.writeListEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('bar', TType.LIST, 3)
+            protocol.writeListBegin(TType.STRING, 3)
+            protocol.writeString('')
+            protocol.writeString('foo')
+            protocol.writeString('bar')
+            protocol.writeListEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getList",1,1,{"1":{"rec":{"1":{"lst":["tf",2,1,0]},"2":{"lst":["i32",3,-128,0,127]},"3":{"lst":["str",3,"","foo","bar"]}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getList",1,1,{"1":{"rec":{"1":{"lst":["tf",2,1,0]},"2":{"lst":["i32",3,-128,0,127]},"3":{"lst":["str",3,"","foo","bar"]}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readListBegin()).to.equal({
+                elementType: TType.BOOL,
+                size: 2,
+            })
+            expect(protocol.readBool()).to.equal(true)
+            expect(protocol.readBool()).to.equal(false)
+            expect(protocol.readListEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readListBegin()).to.equal({
+                elementType: TType.I32,
+                size: 3,
+            })
+            expect(protocol.readI32()).to.equal(-128)
+            expect(protocol.readI32()).to.equal(0)
+            expect(protocol.readI32()).to.equal(127)
+            expect(protocol.readListEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readListBegin()).to.equal({
+                elementType: TType.STRING,
+                size: 3,
+            })
+            expect(protocol.readString()).to.equal('')
+            expect(protocol.readString()).to.equal('foo')
+            expect(protocol.readString()).to.equal('bar')
+            expect(protocol.readListEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('sets', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getSet', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('empty', TType.SET, 1)
+            protocol.writeSetBegin(TType.BOOL, 2)
+            protocol.writeBool(true)
+            protocol.writeBool(false)
+            protocol.writeSetEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('foo', TType.SET, 2)
+            protocol.writeSetBegin(TType.I32, 3)
+            protocol.writeI32(-128)
+            protocol.writeI32(0)
+            protocol.writeI32(127)
+            protocol.writeSetEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('bar', TType.SET, 3)
+            protocol.writeSetBegin(TType.STRING, 3)
+            protocol.writeString('')
+            protocol.writeString('foo')
+            protocol.writeString('bar')
+            protocol.writeSetEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getSet",1,1,{"1":{"rec":{"1":{"set":["tf",2,1,0]},"2":{"set":["i32",3,-128,0,127]},"3":{"set":["str",3,"","foo","bar"]}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getSet",1,1,{"1":{"rec":{"1":{"set":["tf",2,1,0]},"2":{"set":["i32",3,-128,0,127]},"3":{"set":["str",3,"","foo","bar"]}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readSetBegin()).to.equal({
+                elementType: TType.BOOL,
+                size: 2,
+            })
+            expect(protocol.readBool()).to.equal(true)
+            expect(protocol.readBool()).to.equal(false)
+            expect(protocol.readSetEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readSetBegin()).to.equal({
+                elementType: TType.I32,
+                size: 3,
+            })
+            expect(protocol.readI32()).to.equal(-128)
+            expect(protocol.readI32()).to.equal(0)
+            expect(protocol.readI32()).to.equal(127)
+            expect(protocol.readSetEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readSetBegin()).to.equal({
+                elementType: TType.STRING,
+                size: 3,
+            })
+            expect(protocol.readString()).to.equal('')
+            expect(protocol.readString()).to.equal('foo')
+            expect(protocol.readString()).to.equal('bar')
+            expect(protocol.readSetEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+
+    describe('maps', () => {
+        it('should serialize', () => {
+            const transport = new BufferedTransport()
+            const protocol = new JSONProtocol(transport)
+
+            protocol.writeMessageBegin('getMap', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('string-i32', TType.MAP, 1)
+            protocol.writeMapBegin(TType.STRING, TType.I32, 3)
+            protocol.writeString('lower')
+            protocol.writeI32(-128)
+            protocol.writeString('mid')
+            protocol.writeI32(0)
+            protocol.writeString('upper')
+            protocol.writeI32(127)
+            protocol.writeMapEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('i32-bool', TType.MAP, 2)
+            protocol.writeMapBegin(TType.I32, TType.BOOL, 2)
+            protocol.writeI32(0)
+            protocol.writeBool(false)
+            protocol.writeI32(1)
+            protocol.writeBool(true)
+            protocol.writeMapEnd()
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString()).to.equal(
+                `[1,"getMap",1,1,{"1":{"rec":{"1":{"map":["str","i32",3,{"lower":-128,"mid":0,"upper":127}]},"2":{"map":["i32","tf",2,{"0":0,"1":1}]}}}}]`,
+            )
+        })
+
+        it('should deserialize', () => {
+            const buffer = new Buffer(
+                `[1,"getMap",1,1,{"1":{"rec":{"1":{"map":["str","i32",3,{"lower":-128,"mid":0,"upper":127}]},"2":{"map":["i32","tf",2,{"0":0,"1":1}]}}}}]`,
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new JSONProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readMapBegin()).to.equal({
+                keyType: TType.STRING,
+                valueType: TType.I32,
+                size: 3,
+            })
+            expect(protocol.readString()).to.equal('lower')
+            expect(protocol.readI32()).to.equal(-128)
+            expect(protocol.readString()).to.equal('mid')
+            expect(protocol.readI32()).to.equal(0)
+            expect(protocol.readString()).to.equal('upper')
+            expect(protocol.readI32()).to.equal(127)
+            expect(protocol.readMapEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readMapBegin()).to.equal({
+                keyType: TType.I32,
+                valueType: TType.BOOL,
+                size: 2,
+            })
+            expect(protocol.readI32()).to.equal(0)
+            expect(protocol.readBool()).to.equal(false)
+            expect(protocol.readI32()).to.equal(1)
+            expect(protocol.readBool()).to.equal(true)
+            expect(protocol.readMapEnd()).to.be.undefined()
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+    })
+})


### PR DESCRIPTION
As asked before in #94 - here we go

The implementation is mostly based on the original JavaScript implementation in thrift (as annotated in the file).
For parsing the JSON I reworked the `parse_json.js` from the `NodeJS` thrift implementation.

For the tests I generated a server stub with the official java generator, grabbed what is being sent over the wire and build tests around that which brings me to the three small notes.

- representation of double precision IEEE754 floats in JavaScript
Java uses e.g. `1.7976931348623157E308` while JavaScript uses `1.7976931348623157e+308` I checked and both variations parse in both languages - didn't try it in any other languages but seemed "good enough" to me.

- minimum subnormal number in JavaScript
In JS is `5e-324` on the Java side I used `4.9e-324` which is `Double.MIN_VALUE`. Sadly in JavaScript land this get's rounded to 5e-324 which made the serialization/de-serialization test seem a bit weird. That's why I dropped the "lower bound" in the Double test to 4.94e-323 because that does not cause the rounding.

- TTransport.readAll
I added `readAll` to `TTransport` because that hugely improves the ability to parsing the JSON in one go.

Figured the heads-up might be helpful.

If you have any things that I missed/prefer I'd do differently do let me know