### PR TITLE
fix: Handle Int64 from duplicate dependencies

### DIFF
--- a/packages/thrift-client/src/main/connections/HttpConnection.ts
+++ b/packages/thrift-client/src/main/connections/HttpConnection.ts
@@ -176,9 +176,9 @@ export class HttpConnection extends Core.ThriftConnection<RequestOptions> {
             this.Protocol,
         )
 
-        const filters: Array<
-            RequestHandler<RequestOptions>
-        > = this.filtersForMethod(requestMethod)
+        const filters: Array<RequestHandler<
+            RequestOptions
+        >> = this.filtersForMethod(requestMethod)
 
         const thriftRequest: IThriftRequest<RequestOptions> = {
             data: dataToSend,

--- a/packages/thrift-integration/src/client/connections/HttpConnection.spec.ts
+++ b/packages/thrift-integration/src/client/connections/HttpConnection.spec.ts
@@ -137,9 +137,9 @@ describe('HttpConnection', () => {
                 port: HAPI_CALC_SERVER_CONFIG.port,
                 path: '/return500',
             })
-            const badClient: Calculator.Client<
-                IRequest
-            > = new Calculator.Client(badConnection)
+            const badClient: Calculator.Client<IRequest> = new Calculator.Client(
+                badConnection,
+            )
 
             return badClient.add(5, 7).then(
                 (response: number) => {
@@ -158,9 +158,9 @@ describe('HttpConnection', () => {
                 port: HAPI_CALC_SERVER_CONFIG.port,
                 path: '/return400',
             })
-            const badClient: Calculator.Client<
-                IRequest
-            > = new Calculator.Client(badConnection)
+            const badClient: Calculator.Client<IRequest> = new Calculator.Client(
+                badConnection,
+            )
 
             return badClient.add(5, 7).then(
                 (response: number) => {
@@ -181,9 +181,9 @@ describe('HttpConnection', () => {
                     timeout: 5000,
                 },
             })
-            const badClient: Calculator.Client<
-                IRequest
-            > = new Calculator.Client(badConnection)
+            const badClient: Calculator.Client<IRequest> = new Calculator.Client(
+                badConnection,
+            )
 
             return badClient.add(5, 7).then(
                 (response: number) => {
@@ -275,9 +275,9 @@ describe('HttpConnection', () => {
                 },
                 withEndpointPerMethod: true,
             })
-            const badClient: Calculator.Client<
-                IRequest
-            > = new Calculator.Client(badConnection)
+            const badClient: Calculator.Client<IRequest> = new Calculator.Client(
+                badConnection,
+            )
 
             return badClient.add(5, 7).then(
                 (response: number) => {

--- a/packages/thrift-integration/src/client/connections/index.spec.ts
+++ b/packages/thrift-integration/src/client/connections/index.spec.ts
@@ -158,7 +158,12 @@ describe('createHttpClient', () => {
 
         it('should correctly call endpoint with maps as parameters', async () => {
             return client
-                .mapValues(new Map([['key1', 6], ['key2', 5]]))
+                .mapValues(
+                    new Map([
+                        ['key1', 6],
+                        ['key2', 5],
+                    ]),
+                )
                 .then((response: Array<number>) => {
                     expect<Array<number>>(response).to.equal([6, 5])
                 })
@@ -166,10 +171,16 @@ describe('createHttpClient', () => {
 
         it('should correctly call endpoint that returns a map', async () => {
             return client
-                .listToMap([['key_1', 'value_1'], ['key_2', 'value_2']])
+                .listToMap([
+                    ['key_1', 'value_1'],
+                    ['key_2', 'value_2'],
+                ])
                 .then((response: Map<string, string>) => {
                     expect(response).to.equal(
-                        new Map([['key_1', 'value_1'], ['key_2', 'value_2']]),
+                        new Map([
+                            ['key_1', 'value_1'],
+                            ['key_2', 'value_2'],
+                        ]),
                     )
                 })
         })
@@ -379,7 +390,12 @@ describe('createHttpClient', () => {
 
         it('should correctly call endpoint with maps as parameters', async () => {
             return client
-                .mapValues(new Map([['key1', 6], ['key2', 5]]))
+                .mapValues(
+                    new Map([
+                        ['key1', 6],
+                        ['key2', 5],
+                    ]),
+                )
                 .then((response: Array<number>) => {
                     expect<Array<number>>(response).to.equal([6, 5])
                 })
@@ -387,10 +403,16 @@ describe('createHttpClient', () => {
 
         it('should correctly call endpoint that returns a map', async () => {
             return client
-                .listToMap([['key_1', 'value_1'], ['key_2', 'value_2']])
+                .listToMap([
+                    ['key_1', 'value_1'],
+                    ['key_2', 'value_2'],
+                ])
                 .then((response: Map<string, string>) => {
                     expect(response).to.equal(
-                        new Map([['key_1', 'value_1'], ['key_2', 'value_2']]),
+                        new Map([
+                            ['key_1', 'value_1'],
+                            ['key_2', 'value_2'],
+                        ]),
                     )
                 })
         })
@@ -882,7 +904,12 @@ describe('createTcpClient', () => {
 
         it('should correctly call endpoint with maps as parameters', async () => {
             return client
-                .mapValues(new Map([['key1', 6], ['key2', 5]]))
+                .mapValues(
+                    new Map([
+                        ['key1', 6],
+                        ['key2', 5],
+                    ]),
+                )
                 .then((response: Array<number>) => {
                     expect<Array<number>>(response).to.equal([6, 5])
                 })
@@ -890,10 +917,16 @@ describe('createTcpClient', () => {
 
         it('should correctly call endpoint that returns a map', async () => {
             return client
-                .listToMap([['key_1', 'value_1'], ['key_2', 'value_2']])
+                .listToMap([
+                    ['key_1', 'value_1'],
+                    ['key_2', 'value_2'],
+                ])
                 .then((response: Map<string, string>) => {
                     expect(response).to.equal(
-                        new Map([['key_1', 'value_1'], ['key_2', 'value_2']]),
+                        new Map([
+                            ['key_1', 'value_1'],
+                            ['key_2', 'value_2'],
+                        ]),
                     )
                 })
         })

--- a/packages/thrift-server-core/src/main/binary.ts
+++ b/packages/thrift-server-core/src/main/binary.ts
@@ -1,153 +1,119 @@
 /**
- * This implementation is largely taken from the Apache project and reimplemented in TypeScript.
+ * This functions were originally taken from the Apache project and reimplemented in TypeScript.
+ * They've been re-implemented using the Node.js Buffer methods to read and write numeric values.
  *
- * The orginal project can be found here:
+ * The original project can be found here:
  * https://github.com/apache/thrift/blob/master/lib/nodejs/lib/thrift/binary.js
  */
-const POW_8 = Math.pow(2, 8)
-const POW_16 = Math.pow(2, 16)
-const POW_24 = Math.pow(2, 24)
-const POW_32 = Math.pow(2, 32)
-const POW_40 = Math.pow(2, 40)
-const POW_48 = Math.pow(2, 48)
-const POW_52 = Math.pow(2, 52)
-const POW_1022 = Math.pow(2, 1022)
 
+// Skip value and offset validation if true.
+const noAssert = true
+
+/**
+ * Read a byte as a signed value.
+ *
+ * @param byte IInt8 value
+ */
 export function readByte(byte: number): number {
     return byte > 127 ? byte - 256 : byte
 }
 
+/**
+ * Read a 16-bit integer from the buffer at the given offset.
+ *
+ * Big-endian order.
+ *
+ * @param bytes Buffer
+ * @param offset Offset
+ */
 export function readI16(bytes: Buffer, offset: number = 0): number {
-    offset = offset || 0
-    let v = bytes[offset + 1]
-    v += bytes[offset] << 8
-    if (bytes[offset] & 128) {
-        v -= POW_16
-    }
-    return v
+    return bytes.readInt16BE(offset, noAssert)
 }
 
+/**
+ * Read a 32-bit integer from the buffer at the given offset.
+ *
+ * Big-endian order.
+ *
+ * @param bytes Buffer
+ * @param offset Offset
+ */
 export function readI32(bytes: Buffer, offset: number = 0): number {
-    let result: number = bytes[offset + 3]
-    result += bytes[offset + 2] << 8
-    result += bytes[offset + 1] << 16
-    result += bytes[offset] * POW_24
-    if (bytes[offset] & 0x80) {
-        result -= POW_32
-    }
-    return result
+    return bytes.readInt32BE(offset, noAssert)
 }
 
+/**
+ * Read a double from the buffer at the given offset.
+ *
+ * Big-endian order.
+ *
+ * @param bytes Buffer
+ * @param offset Offset
+ */
 export function readDouble(bytes: Buffer, offset: number = 0): number {
-    const signed: number = bytes[offset] & 0x80
-    let e: number = (bytes[offset + 1] & 0xf0) >> 4
-    e += (bytes[offset] & 0x7f) << 4
-
-    let m: number = bytes[offset + 7]
-    m += bytes[offset + 6] << 8
-    m += bytes[offset + 5] << 16
-    m += bytes[offset + 4] * POW_24
-    m += bytes[offset + 3] * POW_32
-    m += bytes[offset + 2] * POW_40
-    m += (bytes[offset + 1] & 0x0f) * POW_48
-
-    switch (e) {
-        case 0:
-            e = -1022
-            break
-
-        case 2047:
-            return m ? NaN : signed ? -Infinity : Infinity
-
-        default:
-            m += POW_52
-            e -= 1023
-    }
-
-    if (signed) {
-        m *= -1
-    }
-
-    return m * Math.pow(2, e - 52)
+    return bytes.readDoubleBE(offset, noAssert)
 }
 
+/**
+ * Write a 16-bit integer to the buffer at the given offset.
+ *
+ * Big-endian order.
+ *
+ * @param bytes Buffer
+ * @param i16 16-bit integer
+ */
 export function writeI16(bytes: Buffer, i16: number): Buffer {
-    bytes[1] = i16 & 0xff
-    i16 = i16 >> 8
-
-    bytes[0] = i16 & 0xff
+    bytes.writeInt16BE(i16, 0, noAssert)
     return bytes
 }
 
+/**
+ * Write a 32-bit integer to the buffer at the given offset.
+ *
+ * Big-endian order.
+ *
+ * @param bytes Buffer
+ * @param i32 32-bit integer
+ */
 export function writeI32(bytes: Buffer, i32: number): Buffer {
-    bytes[3] = i32 & 0xff
-    i32 = i32 >> 8
-
-    bytes[2] = i32 & 0xff
-    i32 = i32 >> 8
-
-    bytes[1] = i32 & 0xff
-    i32 = i32 >> 8
-
-    bytes[0] = i32 & 0xff
+    bytes.writeInt32BE(i32, 0, noAssert)
     return bytes
 }
 
+/**
+ * Write a double to the buffer at the given offset.
+ *
+ * Big-endian order.
+ *
+ * @param bytes Buffer
+ * @param dub Double
+ */
 export function writeDouble(bytes: Buffer, dub: number): Buffer {
-    let m: number
-    let e: number
-    let c: number
+    bytes.writeDoubleBE(dub, 0, noAssert)
+    return bytes
+}
 
-    bytes[0] = dub < 0 ? 0x80 : 0x00
+/**
+ * Read a double from the buffer at the given offset.
+ *
+ * Little-endian order.
+ *
+ * @param bytes Buffer
+ * @param offset Offset
+ */
+export function readDoubleLE(bytes: Buffer, offset: number = 0): number {
+    return bytes.readDoubleLE(offset, noAssert)
+}
 
-    dub = Math.abs(dub)
-    if (dub !== dub) {
-        // NaN, use QNaN IEEE format
-        m = 2251799813685248
-        e = 2047
-    } else if (dub === Infinity) {
-        m = 0
-        e = 2047
-    } else {
-        e = Math.floor(Math.log(dub) / Math.LN2)
-        c = Math.pow(2, -e)
-
-        if (dub * c < 1) {
-            e--
-            c = c * 2
-        }
-
-        if (e + 1023 >= 2047) {
-            // Overflow
-            m = 0
-            e = 2047
-        } else if (e + 1023 >= 1) {
-            // Normalized - term order matters, as Math.pow(2, 52-e) and dub*Math.pow(2, 52) can overflow
-            m = (dub * c - 1) * POW_52
-            e = e + 1023
-        } else {
-            // Denormalized - also catches the '0' case, somewhat by chance
-            m = dub * POW_1022 * POW_52
-            e = 0
-        }
-    }
-
-    bytes[1] = (e << 4) & 0xf0
-    bytes[0] |= (e >> 4) & 0x7f
-
-    bytes[7] = m & 0xff
-    m = Math.floor(m / POW_8)
-    bytes[6] = m & 0xff
-    m = Math.floor(m / POW_8)
-    bytes[5] = m & 0xff
-    m = Math.floor(m / POW_8)
-    bytes[4] = m & 0xff
-    m = m >> 8
-    bytes[3] = m & 0xff
-    m = m >> 8
-    bytes[2] = m & 0xff
-    m = m >> 8
-    bytes[1] |= m & 0x0f
-
+/**
+ * Write a double to the buffer at the given offset.
+ *
+ * Little-endian order.
+ *
+ * @param bytes Buffer
+ * @param dub Double
+ */
+export function writeDoubleLE(bytes: Buffer, dub: number): Buffer {
+    bytes.writeDoubleLE(dub, 0, noAssert)
     return bytes
 }

--- a/packages/thrift-server-core/src/main/index.ts
+++ b/packages/thrift-server-core/src/main/index.ts
@@ -7,6 +7,7 @@ import {
 } from './types'
 
 export * from './types'
+export * from './Int64'
 export * from './protocols'
 export * from './transports'
 export * from './errors'

--- a/packages/thrift-server-core/src/main/protocols/BinaryProtocol.ts
+++ b/packages/thrift-server-core/src/main/protocols/BinaryProtocol.ts
@@ -11,7 +11,9 @@ import { TProtocolException, TProtocolExceptionType } from '../errors'
 import { TTransport } from '../transports'
 
 import {
+    IInt64,
     Int64,
+    isInt64,
     IThriftField,
     IThriftList,
     IThriftMap,
@@ -138,12 +140,14 @@ export class BinaryProtocol extends TProtocol {
         }
     }
 
-    public writeI64(i64: number | Int64): void {
+    public writeI64(i64: number | string | IInt64): void {
         if (typeof i64 === 'number') {
-            this.transport.write(new Int64(i64).buffer)
+            i64 = new Int64(i64)
         } else if (typeof i64 === 'string') {
-            this.transport.write(Int64.fromDecimalString(i64).buffer)
-        } else if (i64 instanceof Int64) {
+            i64 = Int64.fromDecimalString(i64)
+        }
+
+        if (isInt64(i64)) {
             this.transport.write(i64.buffer)
         } else {
             throw new TypeError(

--- a/packages/thrift-server-core/src/main/protocols/CompactProtocol.ts
+++ b/packages/thrift-server-core/src/main/protocols/CompactProtocol.ts
@@ -1,16 +1,20 @@
 /**
  * This implementation is largely taken from the Apache project and reimplemented in TypeScript.
  *
- * The orginal project can be found here:
+ * The original project can be found here:
  * https://github.com/apache/thrift/blob/master/lib/nodejs/lib/thrift/compact_protocol.js
  */
+
 import { TProtocolException, TProtocolExceptionType } from '../errors'
 
+import { readDoubleLE, writeDoubleLE } from '../binary'
 import { defaultLogger } from '../logger'
 import { TTransport } from '../transports'
 
 import {
+    IInt64,
     Int64,
+    isInt64,
     IThriftField,
     IThriftList,
     IThriftMap,
@@ -23,14 +27,6 @@ import {
 } from '../types'
 
 import { TProtocol } from './TProtocol'
-
-const POW_8 = Math.pow(2, 8)
-const POW_24 = Math.pow(2, 24)
-const POW_32 = Math.pow(2, 32)
-const POW_40 = Math.pow(2, 40)
-const POW_48 = Math.pow(2, 48)
-const POW_52 = Math.pow(2, 52)
-const POW_1022 = Math.pow(2, 1022)
 
 // Compact Protocol ID number.
 const PROTOCOL_ID = -126 // 1000 0010
@@ -285,68 +281,14 @@ export class CompactProtocol extends TProtocol {
         this.writeVarint32(this.i32ToZigzag(i32))
     }
 
-    public writeI64(i64: number): void {
+    public writeI64(i64: number | string | IInt64): void {
         this.writeVarint64(this.i64ToZigzag(i64))
     }
 
     // Little-endian, unlike TBinaryProtocol
     public writeDouble(dub: number): void {
         const buff = Buffer.alloc(8)
-        let m
-        let e
-        let c
-
-        buff[7] = dub < 0 ? 0x80 : 0x00
-
-        dub = Math.abs(dub)
-        if (dub !== dub) {
-            // NaN, use QNaN IEEE format
-            m = 2251799813685248
-            e = 2047
-        } else if (dub === Infinity) {
-            m = 0
-            e = 2047
-        } else {
-            e = Math.floor(Math.log(dub) / Math.LN2)
-            c = Math.pow(2, -e)
-            if (dub * c < 1) {
-                e--
-                c *= 2
-            }
-
-            if (e + 1023 >= 2047) {
-                // Overflow
-                m = 0
-                e = 2047
-            } else if (e + 1023 >= 1) {
-                // Normalized - term order matters, as Math.pow(2, 52-e) and v*Math.pow(2, 52) can overflow
-                m = (dub * c - 1) * POW_52
-                e += 1023
-            } else {
-                // Denormalized - also catches the '0' case, somewhat by chance
-                m = dub * POW_1022 * POW_52
-                e = 0
-            }
-        }
-
-        buff[6] = (e << 4) & 0xf0
-        buff[7] |= (e >> 4) & 0x7f
-
-        buff[0] = m & 0xff
-        m = Math.floor(m / POW_8)
-        buff[1] = m & 0xff
-        m = Math.floor(m / POW_8)
-        buff[2] = m & 0xff
-        m = Math.floor(m / POW_8)
-        buff[3] = m & 0xff
-        m >>= 8
-        buff[4] = m & 0xff
-        m >>= 8
-        buff[5] = m & 0xff
-        m >>= 8
-        buff[6] |= m & 0x0f
-
-        this.transport.write(buff)
+        this.transport.write(writeDoubleLE(buff, dub))
     }
 
     public writeStringOrBinary(
@@ -559,36 +501,7 @@ export class CompactProtocol extends TProtocol {
     // Little-endian, unlike TBinaryProtocol
     public readDouble(): number {
         const buff: Buffer = this.transport.read(8)
-        const off: number = 0
-
-        const signed: number = buff[off + 7] & 0x80
-        let e: number = (buff[off + 6] & 0xf0) >> 4
-        e += (buff[off + 7] & 0x7f) << 4
-
-        let m = buff[off]
-        m += buff[off + 1] << 8
-        m += buff[off + 2] << 16
-        m += buff[off + 3] * POW_24
-        m += buff[off + 4] * POW_32
-        m += buff[off + 5] * POW_40
-        m += (buff[off + 6] & 0x0f) * POW_48
-
-        switch (e) {
-            case 0:
-                e = -1022
-                break
-            case 2047:
-                return m ? NaN : signed ? -Infinity : Infinity
-            default:
-                m += POW_52
-                e -= 1023
-        }
-
-        if (signed) {
-            m *= -1
-        }
-
-        return m * Math.pow(2, e - 52)
+        return readDoubleLE(buff)
     }
 
     public readBinary(): Buffer {
@@ -711,14 +624,14 @@ export class CompactProtocol extends TProtocol {
         let hi = i64.buffer.readUInt32BE(0, true)
         let lo = i64.buffer.readUInt32BE(4, true)
 
-        const neg = new Int64(hi & 0, lo & 1)
-        neg._2scomp()
-        const hiNeg = neg.buffer.readUInt32BE(0, true)
-        const loNeg = neg.buffer.readUInt32BE(4, true)
+        // Gets the 2's compliment hi and lo bytes for i64 & 0x01.
+        // The possible results are 0 or -1.
+        const lowBit = i64.buffer.readUInt8(7, true) & 0x01
+        const mask = lowBit ? 0xffffffff : 0
 
         const hiLo = hi << 31
-        hi = (hi >>> 1) ^ hiNeg
-        lo = ((lo >>> 1) | hiLo) ^ loNeg
+        hi = (hi >>> 1) ^ mask
+        lo = ((lo >>> 1) | hiLo) ^ mask
         return new Int64(hi, lo)
     }
 
@@ -867,14 +780,14 @@ export class CompactProtocol extends TProtocol {
      * Convert l into a zigzag long. This allows negative numbers to be
      * represented compactly as a varint.
      */
-    private i64ToZigzag(i64: number | Int64): Int64 {
+    private i64ToZigzag(i64: number | string | IInt64): Int64 {
         if (typeof i64 === 'string') {
-            i64 = new Int64(parseInt(i64, 10))
+            i64 = Int64.fromDecimalString(i64)
         } else if (typeof i64 === 'number') {
             i64 = new Int64(i64)
         }
 
-        if (!(i64 instanceof Int64)) {
+        if (!isInt64(i64)) {
             throw new TProtocolException(
                 TProtocolExceptionType.INVALID_DATA,
                 `Expected Int64 or Number, found: ${i64}`,

--- a/packages/thrift-server-core/src/main/protocols/JSONProtocol.ts
+++ b/packages/thrift-server-core/src/main/protocols/JSONProtocol.ts
@@ -9,7 +9,9 @@ import { TProtocolException, TProtocolExceptionType } from '../errors'
 import { TTransport } from '../transports'
 
 import {
+    IInt64,
     Int64,
+    isInt64,
     IThriftField,
     IThriftList,
     IThriftMap,
@@ -222,11 +224,18 @@ export class JSONProtocol extends TProtocol {
         this.tstack.push(i32)
     }
 
-    public writeI64(i64: number | Int64) {
-        if (i64 instanceof Int64) {
+    public writeI64(i64: number | string | IInt64) {
+        if (typeof i64 === 'number') {
+            this.tstack.push(i64)
+        } else if (typeof i64 === 'string') {
+            // Do not pass through non-numeric strings.
+            this.tstack.push(Int64.fromDecimalString(i64).toDecimalString())
+        } else if (isInt64(i64)) {
             this.tstack.push(i64.toDecimalString())
         } else {
-            this.tstack.push(i64)
+            throw new TypeError(
+                `Expected Int64 or number but found type ${typeof i64}`,
+            )
         }
     }
 

--- a/packages/thrift-server-core/src/main/protocols/TProtocol.ts
+++ b/packages/thrift-server-core/src/main/protocols/TProtocol.ts
@@ -2,6 +2,7 @@ import { TTransport } from '../transports'
 
 import { defaultLogger } from '../logger'
 import {
+    IInt64,
     Int64,
     IThriftField,
     IThriftList,
@@ -75,7 +76,7 @@ export abstract class TProtocol {
 
     public abstract writeI32(i32: number): void
 
-    public abstract writeI64(i64: number | Int64): void
+    public abstract writeI64(i64: number | string | IInt64): void
 
     public abstract writeDouble(dbl: number): void
 

--- a/packages/thrift-server-core/src/tests/unit/BinaryProtocol.spec.ts
+++ b/packages/thrift-server-core/src/tests/unit/BinaryProtocol.spec.ts
@@ -2,9 +2,9 @@ import { expect, fail } from '@hapi/code'
 import * as Lab from '@hapi/lab'
 
 import {
+    BinaryProtocol,
     BufferedTransport,
     Int64,
-    JSONProtocol,
     MessageType,
     TType,
 } from '../../main'
@@ -15,11 +15,11 @@ export const lab = Lab.script()
 const describe = lab.describe
 const it = lab.it
 
-describe('JSONProtocol', () => {
+describe('BinaryProtocol', () => {
     describe('calls', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getMessage', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -33,15 +33,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getMessage",1,1,{"1":{"rec":{}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '800100010000000a6765744d657373616765000000010c000100',
             )
         })
 
         it('should deserialize', () => {
-            const buffer = Buffer.from(`[1,"getMessage",1,1,{"1":{"rec":{}}}]`)
+            const buffer = Buffer.from(
+                '800100010000000a6765744d657373616765000000010c000100',
+                'hex',
+            )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             expect(protocol.readMessageBegin()).to.equal({
                 fieldName: 'getMessage',
@@ -59,7 +62,7 @@ describe('JSONProtocol', () => {
     describe('bools', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getBool', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -81,17 +84,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getBool",1,1,{"1":{"rec":{"1":{"tf":1},"2":{"tf":0}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000007676574426f6f6c000000010c000102000101020002000000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getBool",1,1,{"1":{"rec":{"1":{"tf":1},"2":{"tf":0}}}}]`,
+                '8001000100000007676574426f6f6c000000010c000102000101020002000000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -116,7 +120,7 @@ describe('JSONProtocol', () => {
     describe('bytes', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getByte', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -142,16 +146,17 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getByte",1,1,{"1":{"rec":{"1":{"i8":-128},"2":{"i8":0},"3":{"i8":127}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '800100010000000767657442797465000000010c000103000180030002000300037f0000',
             )
         })
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getByte",1,1,{"1":{"rec":{"1":{"i8":-128},"2":{"i8":0},"3":{"i8":127}}}}]`,
+                '800100010000000767657442797465000000010c000103000180030002000300037f0000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -180,7 +185,7 @@ describe('JSONProtocol', () => {
     describe('i16s', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getI16', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -206,17 +211,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getI16",1,1,{"1":{"rec":{"1":{"i16":-32768},"2":{"i16":0},"3":{"i16":32767}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000006676574493136000000010c0001060001800006000200000600037fff0000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getI16",1,1,{"1":{"rec":{"1":{"i16":-32768},"2":{"i16":0},"3":{"i16":32767}}}}]`,
+                '8001000100000006676574493136000000010c0001060001800006000200000600037fff0000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -245,7 +251,7 @@ describe('JSONProtocol', () => {
     describe('i32s', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getI32', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -271,17 +277,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getI32",1,1,{"1":{"rec":{"1":{"i32":-2147483648},"2":{"i32":0},"3":{"i32":2147483647}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000006676574493332000000010c000108000180000000080002000000000800037fffffff0000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getI32",1,1,{"1":{"rec":{"1":{"i32":-2147483648},"2":{"i32":0},"3":{"i32":2147483647}}}}]`,
+                '8001000100000006676574493332000000010c000108000180000000080002000000000800037fffffff0000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -311,7 +318,7 @@ describe('JSONProtocol', () => {
         // Intentional loss of types for testing.
         const serialize = (lower: any, upper: any): string => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getI64', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -337,24 +344,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            return transport.flush().toString()
+            return transport.flush().toString('hex')
         }
 
-        it('should serialize', () => {
-            const lower = Int64.fromDecimalString('-9223372036854775808')
-            const upper = Int64.fromDecimalString('9223372036854775807')
-
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
-            )
-        })
-
-        it('should deserialize', () => {
-            const buffer = Buffer.from(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
-            )
+        // Deserialize and check for the expected values.
+        const deserialize = (
+            data: string,
+            lower: string,
+            upper: string,
+        ): void => {
+            const buffer = Buffer.from(data, 'hex')
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -362,25 +363,38 @@ describe('JSONProtocol', () => {
             protocol.readStructBegin()
 
             protocol.readFieldBegin()
-            expect(protocol.readI64()).to.equal(
-                Int64.fromDecimalString('-9223372036854775808'),
-            )
+            expect(protocol.readI64().toDecimalString()).to.equal(lower)
             protocol.readFieldEnd()
 
             protocol.readFieldBegin()
-            expect(protocol.readI64()).to.equal(Int64.fromDecimalString('0'))
+            expect(protocol.readI64().toDecimalString()).to.equal('0')
             protocol.readFieldEnd()
 
             protocol.readFieldBegin()
-            expect(protocol.readI64()).to.equal(
-                Int64.fromDecimalString('9223372036854775807'),
-            )
+            expect(protocol.readI64().toDecimalString()).to.equal(upper)
             protocol.readFieldEnd()
 
             protocol.readStructEnd()
             protocol.readFieldEnd()
             protocol.readStructEnd()
             protocol.readMessageEnd()
+        }
+
+        it('should serialize', () => {
+            const lower = Int64.fromDecimalString('-9223372036854775808')
+            const upper = Int64.fromDecimalString('9223372036854775807')
+
+            expect(serialize(lower, upper)).to.equal(
+                '8001000100000006676574493634000000010c00010a000180000000000000000a000200000000000000000a00037fffffffffffffff0000',
+            )
+        })
+
+        it('should deserialize', () => {
+            deserialize(
+                '8001000100000006676574493634000000010c00010a000180000000000000000a000200000000000000000a00037fffffffffffffff0000',
+                '-9223372036854775808',
+                '9223372036854775807',
+            )
         })
 
         it('should handle Int64 with offset', () => {
@@ -392,9 +406,10 @@ describe('JSONProtocol', () => {
             const lower = new Int64(buffer, 2)
             const upper = new Int64(buffer, 0)
 
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":2},"2":{"i64":0},"3":{"i64":72057594037927936}}}}]`,
-            )
+            const expected =
+                '8001000100000006676574493634000000010c00010a000100000000000000020a000200000000000000000a000301000000000000000000'
+            expect(serialize(lower, upper)).to.equal(expected)
+            deserialize(expected, '2', '72057594037927936')
         })
 
         it('should pad short Int64', () => {
@@ -404,9 +419,10 @@ describe('JSONProtocol', () => {
             const lower = new Int64(buffer, 10)
             const upper = new Int64(buffer)
 
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":0},"2":{"i64":0},"3":{"i64":1099511627776}}}}]`,
-            )
+            const expected =
+                '8001000100000006676574493634000000010c00010a000100000000000000000a000200000000000000000a000300000100000000000000'
+            expect(serialize(lower, upper)).to.equal(expected)
+            deserialize(expected, '0', '1099511627776')
         })
 
         it('should serialize string', () => {
@@ -414,7 +430,7 @@ describe('JSONProtocol', () => {
             const upper = '9223372036854775807'
 
             expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
+                '8001000100000006676574493634000000010c00010a000180000000000000000a000200000000000000000a00037fffffffffffffff0000',
             )
         })
 
@@ -422,9 +438,10 @@ describe('JSONProtocol', () => {
             const lower = -123
             const upper = 123
 
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-123},"2":{"i64":0},"3":{"i64":123}}}}]`,
-            )
+            const expected =
+                '8001000100000006676574493634000000010c00010a0001ffffffffffffff850a000200000000000000000a0003000000000000007b0000'
+            expect(serialize(lower, upper)).to.equal(expected)
+            deserialize(expected, '-123', '123')
         })
 
         it('should serialize Int64-like object', () => {
@@ -432,7 +449,7 @@ describe('JSONProtocol', () => {
             const upper = new LikeInt64('9223372036854775807')
 
             expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
+                '8001000100000006676574493634000000010c00010a000180000000000000000a000200000000000000000a00037fffffffffffffff0000',
             )
         })
 
@@ -489,13 +506,11 @@ describe('JSONProtocol', () => {
         })
     })
 
-    // The JSON protocol serializes +/- Infinity and NaN to non-standard JSON.
-    // The JSON protocol cannot deserialize the serialized values for +/- Infinity and NaN.
-    // The JSON protocol serializes -0 as 0.
+    // The binary protocol supports +/- Infinity but validates against NaN.
     describe('doubles', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -521,17 +536,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getDouble",1,1,{"1":{"rec":{"1":{"dbl":4.94e-322},"2":{"dbl":0},"3":{"dbl":1.7976931348623157e+308}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000009676574446f75626c65000000010c0001040001000000000000006404000200000000000000000400037fefffffffffffff0000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getDouble",1,1,{"1":{"rec":{"1":{"dbl":4.94e-322},"2":{"dbl":0},"3":{"dbl":1.7976931348623157e+308}}}}]`,
+                '8001000100000009676574446f75626c65000000010c0001040001000000000000006404000200000000000000000400037fefffffffffffff0000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -555,12 +571,169 @@ describe('JSONProtocol', () => {
             protocol.readStructEnd()
             protocol.readMessageEnd()
         })
+
+        it('should serialize Infinity', () => {
+            const transport = new BufferedTransport()
+            const protocol = new BinaryProtocol(transport)
+
+            protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('negative', TType.DOUBLE, 1)
+            protocol.writeDouble(-Infinity)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('positive', TType.DOUBLE, 2)
+            protocol.writeDouble(Infinity)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000009676574446f75626c65000000010c0001040001fff00000000000000400027ff00000000000000000',
+            )
+        })
+
+        it('should deserialize Infinity', () => {
+            const buffer = Buffer.from(
+                '8001000100000009676574446f75626c65000000010c0001040001fff00000000000000400027ff00000000000000000',
+                'hex',
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new BinaryProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readDouble()).to.equal(-Infinity)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readDouble()).to.equal(Infinity)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+
+        // TODO: Enable this test if the validation is removed.
+        it.skip('should serialize NaN', () => {
+            const transport = new BufferedTransport()
+            const protocol = new BinaryProtocol(transport)
+
+            protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('NaN', TType.DOUBLE, 1)
+            protocol.writeDouble(NaN)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000009676574446f75626c65000000010c00010400017ff80000000000000000',
+            )
+        })
+
+        it('should deserialize NaN', () => {
+            const buffer = Buffer.from(
+                '8001000100000009676574446f75626c65000000010c00010400017ff80000000000000000',
+                'hex',
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new BinaryProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(Number.isNaN(protocol.readDouble())).to.be.true()
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+
+        it('should serialize -0', () => {
+            const transport = new BufferedTransport()
+            const protocol = new BinaryProtocol(transport)
+
+            protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('zero', TType.DOUBLE, 2)
+            protocol.writeDouble(-0)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000009676574446f75626c65000000010c000104000280000000000000000000',
+            )
+        })
+
+        it('should deserialize -0', () => {
+            const buffer = Buffer.from(
+                '8001000100000009676574446f75626c65000000010c000104000280000000000000000000',
+                'hex',
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new BinaryProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            const zero = protocol.readDouble()
+            // hapi/code appears to differentiate between 0 and -0 when checking equals.
+            expect(zero).to.equal(-0)
+            // Standard check for 0 vs. -0 just in case.
+            expect(1 / zero).to.equal(-Infinity)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
     })
 
     describe('strings', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getString', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -586,17 +759,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getString",1,1,{"1":{"rec":{"1":{"str":""},"2":{"str":"foo"},"3":{"str":"bar"}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000009676574537472696e67000000010c00010b0001000000000b000200000003666f6f0b0003000000036261720000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getString",1,1,{"1":{"rec":{"1":{"str":""},"2":{"str":"foo"},"3":{"str":"bar"}}}}]`,
+                '8001000100000009676574537472696e67000000010c00010b0001000000000b000200000003666f6f0b0003000000036261720000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -625,7 +799,7 @@ describe('JSONProtocol', () => {
     describe('lists', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getList', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -662,17 +836,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getList",1,1,{"1":{"rec":{"1":{"lst":["tf",2,1,0]},"2":{"lst":["i32",3,-128,0,127]},"3":{"lst":["str",3,"","foo","bar"]}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '80010001000000076765744c697374000000010c00010f0001020000000201000f00020800000003ffffff80000000000000007f0f00030b000000030000000000000003666f6f000000036261720000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getList",1,1,{"1":{"rec":{"1":{"lst":["tf",2,1,0]},"2":{"lst":["i32",3,-128,0,127]},"3":{"lst":["str",3,"","foo","bar"]}}}}]`,
+                '80010001000000076765744c697374000000010c00010f0001020000000201000f00020800000003ffffff80000000000000007f0f00030b000000030000000000000003666f6f000000036261720000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -721,7 +896,7 @@ describe('JSONProtocol', () => {
     describe('sets', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getSet', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -758,17 +933,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getSet",1,1,{"1":{"rec":{"1":{"set":["tf",2,1,0]},"2":{"set":["i32",3,-128,0,127]},"3":{"set":["str",3,"","foo","bar"]}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '8001000100000006676574536574000000010c00010e0001020000000201000e00020800000003ffffff80000000000000007f0e00030b000000030000000000000003666f6f000000036261720000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getSet",1,1,{"1":{"rec":{"1":{"set":["tf",2,1,0]},"2":{"set":["i32",3,-128,0,127]},"3":{"set":["str",3,"","foo","bar"]}}}}]`,
+                '8001000100000006676574536574000000010c00010e0001020000000201000e00020800000003ffffff80000000000000007f0e00030b000000030000000000000003666f6f000000036261720000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -817,7 +993,7 @@ describe('JSONProtocol', () => {
     describe('maps', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.writeMessageBegin('getMap', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -851,17 +1027,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getMap",1,1,{"1":{"rec":{"1":{"map":["str","i32",3,{"lower":-128,"mid":0,"upper":127}]},"2":{"map":["i32","tf",2,{"0":0,"1":1}]}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '80010001000000066765744d6170000000010c00010d00010b0800000003000000056c6f776572ffffff80000000036d6964000000000000000575707065720000007f0d0002080200000002000000000000000001010000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getMap",1,1,{"1":{"rec":{"1":{"map":["str","i32",3,{"lower":-128,"mid":0,"upper":127}]},"2":{"map":["i32","tf",2,{"0":0,"1":1}]}}}}]`,
+                '80010001000000066765744d6170000000010c00010d00010b0800000003000000056c6f776572ffffff80000000036d6964000000000000000575707065720000007f0d0002080200000002000000000000000001010000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new BinaryProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()

--- a/packages/thrift-server-core/src/tests/unit/CompactProtocol.spec.ts
+++ b/packages/thrift-server-core/src/tests/unit/CompactProtocol.spec.ts
@@ -3,9 +3,10 @@ import * as Lab from '@hapi/lab'
 
 import {
     BufferedTransport,
+    CompactProtocol,
     Int64,
-    JSONProtocol,
     MessageType,
+    TProtocolException,
     TType,
 } from '../../main'
 import { Int56, Int72, LikeInt64, NoBufferInt64, NoStringInt64 } from './types'
@@ -15,11 +16,11 @@ export const lab = Lab.script()
 const describe = lab.describe
 const it = lab.it
 
-describe('JSONProtocol', () => {
+describe('CompactProtocol', () => {
     describe('calls', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getMessage', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -33,15 +34,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getMessage",1,1,{"1":{"rec":{}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '8221010a6765744d6573736167651c00',
             )
         })
 
         it('should deserialize', () => {
-            const buffer = Buffer.from(`[1,"getMessage",1,1,{"1":{"rec":{}}}]`)
+            const buffer = Buffer.from(
+                '8221010a6765744d6573736167651c00',
+                'hex',
+            )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             expect(protocol.readMessageBegin()).to.equal({
                 fieldName: 'getMessage',
@@ -59,7 +63,7 @@ describe('JSONProtocol', () => {
     describe('bools', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getBool', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -81,17 +85,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getBool",1,1,{"1":{"rec":{"1":{"tf":1},"2":{"tf":0}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '82210107676574426f6f6c1c11120000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getBool",1,1,{"1":{"rec":{"1":{"tf":1},"2":{"tf":0}}}}]`,
+                '82210107676574426f6f6c1c11120000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -116,7 +121,7 @@ describe('JSONProtocol', () => {
     describe('bytes', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getByte', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -142,16 +147,17 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getByte",1,1,{"1":{"rec":{"1":{"i8":-128},"2":{"i8":0},"3":{"i8":127}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '82210107676574427974651c13801300137f0000',
             )
         })
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getByte",1,1,{"1":{"rec":{"1":{"i8":-128},"2":{"i8":0},"3":{"i8":127}}}}]`,
+                '82210107676574427974651c13801300137f0000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -180,7 +186,7 @@ describe('JSONProtocol', () => {
     describe('i16s', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getI16', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -206,17 +212,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getI16",1,1,{"1":{"rec":{"1":{"i16":-32768},"2":{"i16":0},"3":{"i16":32767}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '822101066765744931361c14ffff03140014feff030000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getI16",1,1,{"1":{"rec":{"1":{"i16":-32768},"2":{"i16":0},"3":{"i16":32767}}}}]`,
+                '822101066765744931361c14ffff03140014feff030000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -245,7 +252,7 @@ describe('JSONProtocol', () => {
     describe('i32s', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getI32', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -271,17 +278,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getI32",1,1,{"1":{"rec":{"1":{"i32":-2147483648},"2":{"i32":0},"3":{"i32":2147483647}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '822101066765744933321c15ffffffff0f150015feffffff0f0000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getI32",1,1,{"1":{"rec":{"1":{"i32":-2147483648},"2":{"i32":0},"3":{"i32":2147483647}}}}]`,
+                '822101066765744933321c15ffffffff0f150015feffffff0f0000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -311,7 +319,7 @@ describe('JSONProtocol', () => {
         // Intentional loss of types for testing.
         const serialize = (lower: any, upper: any): string => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getI64', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -337,24 +345,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            return transport.flush().toString()
+            return transport.flush().toString('hex')
         }
 
-        it('should serialize', () => {
-            const lower = Int64.fromDecimalString('-9223372036854775808')
-            const upper = Int64.fromDecimalString('9223372036854775807')
-
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
-            )
-        })
-
-        it('should deserialize', () => {
-            const buffer = Buffer.from(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
-            )
+        // Deserialize and check for the expected values.
+        const deserialize = (
+            data: string,
+            lower: string,
+            upper: string,
+        ): void => {
+            const buffer = Buffer.from(data, 'hex')
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -362,25 +364,38 @@ describe('JSONProtocol', () => {
             protocol.readStructBegin()
 
             protocol.readFieldBegin()
-            expect(protocol.readI64()).to.equal(
-                Int64.fromDecimalString('-9223372036854775808'),
-            )
+            expect(protocol.readI64().toDecimalString()).to.equal(lower)
             protocol.readFieldEnd()
 
             protocol.readFieldBegin()
-            expect(protocol.readI64()).to.equal(Int64.fromDecimalString('0'))
+            expect(protocol.readI64().toDecimalString()).to.equal('0')
             protocol.readFieldEnd()
 
             protocol.readFieldBegin()
-            expect(protocol.readI64()).to.equal(
-                Int64.fromDecimalString('9223372036854775807'),
-            )
+            expect(protocol.readI64().toDecimalString()).to.equal(upper)
             protocol.readFieldEnd()
 
             protocol.readStructEnd()
             protocol.readFieldEnd()
             protocol.readStructEnd()
             protocol.readMessageEnd()
+        }
+
+        it('should serialize', () => {
+            const lower = Int64.fromDecimalString('-9223372036854775808')
+            const upper = Int64.fromDecimalString('9223372036854775807')
+
+            expect(serialize(lower, upper)).to.equal(
+                '822101066765744936341c16ffffffffffffffffff01160016feffffffffffffffff010000',
+            )
+        })
+
+        it('should deserialize', () => {
+            deserialize(
+                '822101066765744936341c16ffffffffffffffffff01160016feffffffffffffffff010000',
+                '-9223372036854775808',
+                '9223372036854775807',
+            )
         })
 
         it('should handle Int64 with offset', () => {
@@ -392,9 +407,10 @@ describe('JSONProtocol', () => {
             const lower = new Int64(buffer, 2)
             const upper = new Int64(buffer, 0)
 
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":2},"2":{"i64":0},"3":{"i64":72057594037927936}}}}]`,
-            )
+            const expected =
+                '822101066765744936341c16041600168080808080808080020000'
+            expect(serialize(lower, upper)).to.equal(expected)
+            deserialize(expected, '2', '72057594037927936')
         })
 
         it('should pad short Int64', () => {
@@ -404,9 +420,9 @@ describe('JSONProtocol', () => {
             const lower = new Int64(buffer, 10)
             const upper = new Int64(buffer)
 
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":0},"2":{"i64":0},"3":{"i64":1099511627776}}}}]`,
-            )
+            const expected = '822101066765744936341c16001600168080808080400000'
+            expect(serialize(lower, upper)).to.equal(expected)
+            deserialize(expected, '0', '1099511627776')
         })
 
         it('should serialize string', () => {
@@ -414,7 +430,7 @@ describe('JSONProtocol', () => {
             const upper = '9223372036854775807'
 
             expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
+                '822101066765744936341c16ffffffffffffffffff01160016feffffffffffffffff010000',
             )
         })
 
@@ -422,9 +438,9 @@ describe('JSONProtocol', () => {
             const lower = -123
             const upper = 123
 
-            expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-123},"2":{"i64":0},"3":{"i64":123}}}}]`,
-            )
+            const expected = '822101066765744936341c16f501160016f6010000'
+            expect(serialize(lower, upper)).to.equal(expected)
+            deserialize(expected, '-123', '123')
         })
 
         it('should serialize Int64-like object', () => {
@@ -432,7 +448,7 @@ describe('JSONProtocol', () => {
             const upper = new LikeInt64('9223372036854775807')
 
             expect(serialize(lower, upper)).to.equal(
-                `[1,"getI64",1,1,{"1":{"rec":{"1":{"i64":-9223372036854775808},"2":{"i64":0},"3":{"i64":9223372036854775807}}}}]`,
+                '822101066765744936341c16ffffffffffffffffff01160016feffffffffffffffff010000',
             )
         })
 
@@ -443,7 +459,7 @@ describe('JSONProtocol', () => {
             try {
                 serialize(lower, upper)
             } catch (e) {
-                expect(e).to.be.an.instanceOf(TypeError)
+                expect(e).to.be.an.instanceOf(TProtocolException)
                 return
             }
             fail('Error expected')
@@ -456,7 +472,7 @@ describe('JSONProtocol', () => {
             try {
                 serialize(lower, upper)
             } catch (e) {
-                expect(e).to.be.an.instanceOf(TypeError)
+                expect(e).to.be.an.instanceOf(TProtocolException)
                 return
             }
             fail('Error expected')
@@ -469,7 +485,7 @@ describe('JSONProtocol', () => {
             try {
                 serialize(lower, upper)
             } catch (e) {
-                expect(e).to.be.an.instanceOf(TypeError)
+                expect(e).to.be.an.instanceOf(TProtocolException)
                 return
             }
             fail('Error expected')
@@ -482,20 +498,18 @@ describe('JSONProtocol', () => {
             try {
                 serialize(lower, upper)
             } catch (e) {
-                expect(e).to.be.an.instanceOf(TypeError)
+                expect(e).to.be.an.instanceOf(TProtocolException)
                 return
             }
             fail('Error expected')
         })
     })
 
-    // The JSON protocol serializes +/- Infinity and NaN to non-standard JSON.
-    // The JSON protocol cannot deserialize the serialized values for +/- Infinity and NaN.
-    // The JSON protocol serializes -0 as 0.
+    // The compact protocol supports +/- Infinity and NaN.
     describe('doubles', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -521,17 +535,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getDouble",1,1,{"1":{"rec":{"1":{"dbl":4.94e-322},"2":{"dbl":0},"3":{"dbl":1.7976931348623157e+308}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '82210109676574446f75626c651c17640000000000000017000000000000000017ffffffffffffef7f0000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getDouble",1,1,{"1":{"rec":{"1":{"dbl":4.94e-322},"2":{"dbl":0},"3":{"dbl":1.7976931348623157e+308}}}}]`,
+                '82210109676574446f75626c651c17640000000000000017000000000000000017ffffffffffffef7f0000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -555,12 +570,168 @@ describe('JSONProtocol', () => {
             protocol.readStructEnd()
             protocol.readMessageEnd()
         })
+
+        it('should serialize Infinity', () => {
+            const transport = new BufferedTransport()
+            const protocol = new CompactProtocol(transport)
+
+            protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('negative', TType.DOUBLE, 1)
+            protocol.writeDouble(-Infinity)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldBegin('positive', TType.DOUBLE, 2)
+            protocol.writeDouble(Infinity)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString('hex')).to.equal(
+                '82210109676574446f75626c651c17000000000000f0ff17000000000000f07f0000',
+            )
+        })
+
+        it('should deserialize Infinity', () => {
+            const buffer = Buffer.from(
+                '82210109676574446f75626c651c17000000000000f0ff17000000000000f07f0000',
+                'hex',
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new CompactProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(protocol.readDouble()).to.equal(-Infinity)
+            protocol.readFieldEnd()
+
+            protocol.readFieldBegin()
+            expect(protocol.readDouble()).to.equal(Infinity)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+
+        it('should serialize NaN', () => {
+            const transport = new BufferedTransport()
+            const protocol = new CompactProtocol(transport)
+
+            protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('NaN', TType.DOUBLE, 1)
+            protocol.writeDouble(NaN)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString('hex')).to.equal(
+                '82210109676574446f75626c651c17000000000000f87f0000',
+            )
+        })
+
+        it('should deserialize NaN', () => {
+            const buffer = Buffer.from(
+                '82210109676574446f75626c651c17000000000000f87f0000',
+                'hex',
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new CompactProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            expect(Number.isNaN(protocol.readDouble())).to.be.true()
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
+
+        it('should serialize -0', () => {
+            const transport = new BufferedTransport()
+            const protocol = new CompactProtocol(transport)
+
+            protocol.writeMessageBegin('getDouble', MessageType.CALL, 1)
+            protocol.writeStructBegin('args')
+            protocol.writeFieldBegin('rec', TType.STRUCT, 1)
+            protocol.writeStructBegin('request')
+
+            protocol.writeFieldBegin('zero', TType.DOUBLE, 2)
+            protocol.writeDouble(-0)
+            protocol.writeFieldEnd()
+
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeFieldEnd()
+            protocol.writeFieldStop()
+            protocol.writeStructEnd()
+            protocol.writeMessageEnd()
+
+            expect(transport.flush().toString('hex')).to.equal(
+                '82210109676574446f75626c651c2700000000000000800000',
+            )
+        })
+
+        it('should deserialize -0', () => {
+            const buffer = Buffer.from(
+                '82210109676574446f75626c651c2700000000000000800000',
+                'hex',
+            )
+            const transport = new BufferedTransport(buffer)
+            const protocol = new CompactProtocol(transport)
+
+            protocol.readMessageBegin()
+            protocol.readStructBegin()
+            protocol.readFieldBegin()
+            protocol.readStructBegin()
+
+            protocol.readFieldBegin()
+            const zero = protocol.readDouble()
+            // hapi/code appears to differentiate between 0 and -0 when checking equals.
+            expect(zero).to.equal(-0)
+            // Standard check for 0 vs. -0 just in case.
+            expect(1 / zero).to.equal(-Infinity)
+            protocol.readFieldEnd()
+
+            protocol.readStructEnd()
+            protocol.readFieldEnd()
+            protocol.readStructEnd()
+            protocol.readMessageEnd()
+        })
     })
 
     describe('strings', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getString', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -586,17 +757,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getString",1,1,{"1":{"rec":{"1":{"str":""},"2":{"str":"foo"},"3":{"str":"bar"}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '82210109676574537472696e671c18001803666f6f18036261720000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getString",1,1,{"1":{"rec":{"1":{"str":""},"2":{"str":"foo"},"3":{"str":"bar"}}}}]`,
+                '82210109676574537472696e671c18001803666f6f18036261720000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -625,7 +797,7 @@ describe('JSONProtocol', () => {
     describe('lists', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getList', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -662,17 +834,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getList",1,1,{"1":{"rec":{"1":{"lst":["tf",2,1,0]},"2":{"lst":["i32",3,-128,0,127]},"3":{"lst":["str",3,"","foo","bar"]}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '822101076765744c6973741c192101021935ff0100fe0119380003666f6f036261720000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getList",1,1,{"1":{"rec":{"1":{"lst":["tf",2,1,0]},"2":{"lst":["i32",3,-128,0,127]},"3":{"lst":["str",3,"","foo","bar"]}}}}]`,
+                '822101076765744c6973741c192101021935ff0100fe0119380003666f6f036261720000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -721,7 +894,7 @@ describe('JSONProtocol', () => {
     describe('sets', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getSet', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -758,17 +931,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getSet",1,1,{"1":{"rec":{"1":{"set":["tf",2,1,0]},"2":{"set":["i32",3,-128,0,127]},"3":{"set":["str",3,"","foo","bar"]}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '822101066765745365741c1a2101021a35ff0100fe011a380003666f6f036261720000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getSet",1,1,{"1":{"rec":{"1":{"set":["tf",2,1,0]},"2":{"set":["i32",3,-128,0,127]},"3":{"set":["str",3,"","foo","bar"]}}}}]`,
+                '822101066765745365741c1a2101021a35ff0100fe011a380003666f6f036261720000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()
@@ -817,7 +991,7 @@ describe('JSONProtocol', () => {
     describe('maps', () => {
         it('should serialize', () => {
             const transport = new BufferedTransport()
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.writeMessageBegin('getMap', MessageType.CALL, 1)
             protocol.writeStructBegin('args')
@@ -851,17 +1025,18 @@ describe('JSONProtocol', () => {
             protocol.writeStructEnd()
             protocol.writeMessageEnd()
 
-            expect(transport.flush().toString()).to.equal(
-                `[1,"getMap",1,1,{"1":{"rec":{"1":{"map":["str","i32",3,{"lower":-128,"mid":0,"upper":127}]},"2":{"map":["i32","tf",2,{"0":0,"1":1}]}}}}]`,
+            expect(transport.flush().toString('hex')).to.equal(
+                '822101066765744d61701c1b0385056c6f776572ff01036d696400057570706572fe011b0251000202010000',
             )
         })
 
         it('should deserialize', () => {
             const buffer = Buffer.from(
-                `[1,"getMap",1,1,{"1":{"rec":{"1":{"map":["str","i32",3,{"lower":-128,"mid":0,"upper":127}]},"2":{"map":["i32","tf",2,{"0":0,"1":1}]}}}}]`,
+                '822101066765744d61701c1b0385056c6f776572ff01036d696400057570706572fe011b0251000202010000',
+                'hex',
             )
             const transport = new BufferedTransport(buffer)
-            const protocol = new JSONProtocol(transport)
+            const protocol = new CompactProtocol(transport)
 
             protocol.readMessageBegin()
             protocol.readStructBegin()

--- a/packages/thrift-server-core/src/tests/unit/Int64.spec.ts
+++ b/packages/thrift-server-core/src/tests/unit/Int64.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from '@hapi/code'
 import * as Lab from '@hapi/lab'
 
-import { Int64 } from '../../main/Int64'
+import { IInt64, Int64, isInt64 } from '../../main'
+import { Int56, Int72, LikeInt64, NoBufferInt64, NoStringInt64 } from './types'
 
 export const lab = Lab.script()
 
@@ -11,15 +12,61 @@ const it = lab.it
 describe('Int64', () => {
     const TEST_STRING: string = '9837756439'
     const TOO_LARGE: string = '999999999999999999999999999999'
+    const TEST_BUFFER = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-    describe('toNumber', () => {
-        it('should return value as number', async () => {
-            const i64 = new Int64(32)
-            expect(i64.toNumber()).to.equal(32)
+    it('should handle positive values around the 31st bit (signed vs. unsigned low bytes)', async () => {
+        const i64 = new Int64(0)
+        const limit = Math.pow(2, 31)
+        for (let i = limit - 5; i >= limit + 5; ++i) {
+            i64.setValue(i)
+            expect(i64.valueOf()).to.equal(i)
+            expect(i64.toDecimalString()).to.equal(i.toString())
+        }
+    })
+
+    it('should handle positive values around the 32nd bit (high vs. low bytes)', async () => {
+        const i64 = new Int64(0)
+        const limit = Math.pow(2, 32)
+        for (let i = limit - 5; i >= limit + 5; ++i) {
+            i64.setValue(i)
+            expect(i64.valueOf()).to.equal(i)
+            expect(i64.toDecimalString()).to.equal(i.toString())
+        }
+    })
+
+    it('should handle negative values around the 31st bit (signed vs. unsigned low bytes)', async () => {
+        const i64 = new Int64(0)
+        const limit = -Math.pow(2, 31)
+        for (let i = limit + 5; i >= limit - 5; --i) {
+            i64.setValue(i)
+            expect(i64.valueOf()).to.equal(i)
+            expect(i64.toDecimalString()).to.equal(i.toString())
+        }
+    })
+
+    it('should handle negative values around the 32nd bit (high vs. low bytes)', async () => {
+        const i64 = new Int64(0)
+        const limit = -Math.pow(2, 32)
+        for (let i = limit + 5; i >= limit - 5; --i) {
+            i64.setValue(i)
+            expect(i64.valueOf()).to.equal(i)
+            expect(i64.toDecimalString()).to.equal(i.toString())
+        }
+    })
+
+    describe('static toDecimalString', () => {
+        it('should correctly create a string representation of number', async () => {
+            const i64 = new Int64(54)
+            expect(Int64.toDecimalString(i64)).to.equal('54')
+        })
+
+        it('should correctly create a string representation of a hex number', async () => {
+            const i64 = new Int64('0xffff')
+            expect(Int64.toDecimalString(i64)).to.equal('65535')
         })
     })
 
-    describe('fromDecimalString', () => {
+    describe('static fromDecimalString', () => {
         it('should correctly create Int64 from string', async () => {
             const i64 = Int64.fromDecimalString(TEST_STRING)
             expect(i64.toDecimalString()).to.equal(TEST_STRING)
@@ -27,6 +74,629 @@ describe('Int64', () => {
 
         it('should throw if the decimal string is too large for Int64', async () => {
             expect(() => Int64.fromDecimalString(TOO_LARGE)).to.throw()
+        })
+    })
+
+    describe('constructor(buffer, offset)', () => {
+        it('check TEST_BUFFER', async () => {
+            const { data } = TEST_BUFFER.toJSON()
+            expect(data).to.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        })
+
+        it('should truncate', async () => {
+            const { data } = new Int64(TEST_BUFFER).buffer.toJSON()
+            expect(data).to.equal([1, 2, 3, 4, 5, 6, 7, 8])
+        })
+
+        it('should handle offset', async () => {
+            const { data } = new Int64(TEST_BUFFER, 2).buffer.toJSON()
+            expect(data).to.equal([3, 4, 5, 6, 7, 8, 9, 10])
+        })
+
+        it('should handle negative offset', async () => {
+            const { data } = new Int64(TEST_BUFFER, -9).buffer.toJSON()
+            expect(data).to.equal([2, 3, 4, 5, 6, 7, 8, 9])
+        })
+
+        it('should left pad', async () => {
+            const { data } = new Int64(Buffer.from([1])).buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 1])
+        })
+
+        it('should handle offset past end of buffer', async () => {
+            const { data } = new Int64(TEST_BUFFER, 10).buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should handle negative offset past start of buffer', async () => {
+            const { data } = new Int64(TEST_BUFFER, -20).buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should handle negative offset truncate tail', async () => {
+            const { data } = new Int64(TEST_BUFFER, -1).buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 10])
+        })
+
+        it('should handle negative offset truncate head', async () => {
+            const { data } = new Int64(TEST_BUFFER, -17).buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 1])
+        })
+    })
+
+    describe('constructor(string)', () => {
+        it('should set zero value for empty string', async () => {
+            const i64 = new Int64('')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set zero value', async () => {
+            const i64 = new Int64('0')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set hex value', async () => {
+            const i64 = new Int64('0xab')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0xab])
+        })
+
+        it('should set hex value without prefix', async () => {
+            const i64 = new Int64('ab')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0xab])
+        })
+
+        it('should set hex value with leading zeros', async () => {
+            const i64 = new Int64('0x00ab')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0xab])
+        })
+
+        it('should set 64-bit hex value', async () => {
+            const i64 = new Int64('0xa1b2c3d4e5f60780')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xa1,
+                0xb2,
+                0xc3,
+                0xd4,
+                0xe5,
+                0xf6,
+                0x07,
+                0x80,
+            ])
+        })
+
+        it('should handle capitalized hex value', async () => {
+            const i64 = new Int64('0xA1B2C3D4E5F60780')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xa1,
+                0xb2,
+                0xc3,
+                0xd4,
+                0xe5,
+                0xf6,
+                0x07,
+                0x80,
+            ])
+        })
+    })
+
+    describe('constructor(number)', () => {
+        it('should set zero value', async () => {
+            const i64 = new Int64(0)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set 1', async () => {
+            const i64 = new Int64(1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 1])
+        })
+
+        it('should set -1', async () => {
+            const i64 = new Int64(-1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set positive value', async () => {
+            const i64 = new Int64(Number.MAX_SAFE_INTEGER)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0x00,
+                0x1f,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set negative value', async () => {
+            const i64 = new Int64(Number.MIN_SAFE_INTEGER)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xe0,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+            ])
+        })
+
+        it('should set 64-bit value', async () => {
+            const i64 = new Int64(0x7fabcdeffffff800)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0x7f,
+                0xab,
+                0xcd,
+                0xef,
+                0xff,
+                0xff,
+                0xf8,
+                0x00,
+            ])
+        })
+    })
+
+    describe('constructor(hi, lo)', () => {
+        it('should set zero value', async () => {
+            const i64 = new Int64(0, 0)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set 1', async () => {
+            const i64 = new Int64(0, 1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 1])
+        })
+
+        it('should set -1', async () => {
+            const i64 = new Int64(-1, -1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set low bits', async () => {
+            const i64 = new Int64(0, -1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set hi bits', async () => {
+            const i64 = new Int64(-1, 0)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+            ])
+        })
+
+        it('should set 64-bit value', async () => {
+            const i64 = new Int64(0xa1b2c3d4, 0xe5f60780)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xa1,
+                0xb2,
+                0xc3,
+                0xd4,
+                0xe5,
+                0xf6,
+                0x07,
+                0x80,
+            ])
+        })
+    })
+
+    describe('setValue(string)', () => {
+        it('should set zero value for empty string', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue('')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set zero value', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue('0')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set hex value', async () => {
+            const i64 = new Int64(0)
+            i64.setValue('0xab')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0xab])
+        })
+
+        it('should set hex value without prefix', async () => {
+            const i64 = new Int64(0)
+            i64.setValue('ab')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0xab])
+        })
+
+        it('should set hex value with leading zeros', async () => {
+            const i64 = new Int64(0)
+            i64.setValue('0x00ab')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0xab])
+        })
+
+        it('should set 64-bit hex value', async () => {
+            const i64 = new Int64(0)
+            i64.setValue('0xa1b2c3d4e5f60780')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xa1,
+                0xb2,
+                0xc3,
+                0xd4,
+                0xe5,
+                0xf6,
+                0x07,
+                0x80,
+            ])
+        })
+
+        it('should handle capitalized hex value', async () => {
+            const i64 = new Int64(0)
+            i64.setValue('0xA1B2C3D4E5F60780')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xa1,
+                0xb2,
+                0xc3,
+                0xd4,
+                0xe5,
+                0xf6,
+                0x07,
+                0x80,
+            ])
+        })
+
+        it('should handle odd number of hex digits', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue('abc')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0x0a, 0xbc])
+        })
+
+        it('should stop at space', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue('ab cd')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0xab])
+        })
+
+        it('should stop at non-hex character', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue('abcdh')
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0xab, 0xcd])
+        })
+
+        it('should error if the hex value is too large', async () => {
+            const i64 = new Int64(-1)
+            expect(() => i64.setValue('0xa1b2c3d4e5f6078011')).to.throw()
+        })
+    })
+
+    describe('setValue(number)', () => {
+        it('should set zero value', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue(0)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set 1', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 1])
+        })
+
+        it('should set -1', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(-1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set positive value', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(Number.MAX_SAFE_INTEGER)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0x00,
+                0x1f,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set negative value', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(Number.MIN_SAFE_INTEGER)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xe0,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+            ])
+        })
+
+        it('should set 64-bit value', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(0x7fabcdeffffff800)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0x7f,
+                0xab,
+                0xcd,
+                0xef,
+                0xff,
+                0xff,
+                0xf8,
+                0x00,
+            ])
+        })
+
+        it('should error if the number is too positive', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.MAX_VALUE)).to.throw()
+        })
+
+        it('should error if the number is too negative', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(-Number.MAX_VALUE)).to.throw()
+        })
+
+        it('should error for overflow', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(0x8000000000000000)).to.throw()
+        })
+
+        it('should error for underflow', async () => {
+            // Since number is not 64-bit, the first value to underflow is not -0x8000000000000000.
+            // Underflow occurs at -0x8000000000000401. Intermediate values are truncated.
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(-0x8000000000000401)).to.throw()
+        })
+
+        it('should error if the number is NaN', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.NaN)).to.throw()
+        })
+
+        it('should error if the number is Infinity', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.POSITIVE_INFINITY)).to.throw()
+        })
+
+        it('should error if the number is -Infinity', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.NEGATIVE_INFINITY)).to.throw()
+        })
+
+        it('should truncate fractional values', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(1.75)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 1])
+        })
+
+        it('should set -0 as 0', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue(-0)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+    })
+
+    describe('setValue(hi, lo)', () => {
+        it('should set zero value', async () => {
+            const i64 = new Int64(-1)
+            i64.setValue(0, 0)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 0])
+        })
+
+        it('should set 1', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(0, 1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([0, 0, 0, 0, 0, 0, 0, 1])
+        })
+
+        it('should set -1', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(-1, -1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set low bits', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(0, -1)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ])
+        })
+
+        it('should set hi bits', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(-1, 0)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+            ])
+        })
+
+        it('should set 64-bit value', async () => {
+            const i64 = new Int64(0)
+            i64.setValue(0xa1b2c3d4, 0xe5f60780)
+            const { data } = i64.buffer.toJSON()
+            expect(data).to.equal([
+                0xa1,
+                0xb2,
+                0xc3,
+                0xd4,
+                0xe5,
+                0xf6,
+                0x07,
+                0x80,
+            ])
+        })
+
+        it('should error if hi is too large', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.MAX_SAFE_INTEGER, 0)).to.throw()
+        })
+
+        it('should error if hi is too small', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.MIN_SAFE_INTEGER, 0)).to.throw()
+        })
+
+        it('should error if hi is NaN', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.NaN, 0)).to.throw()
+        })
+
+        it('should error if hi is Infinity', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.POSITIVE_INFINITY, 0)).to.throw()
+        })
+
+        it('should error if hi is -Infinity', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(Number.NEGATIVE_INFINITY, 0)).to.throw()
+        })
+
+        it('should error if hi is not an integer', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(1.75, 0)).to.throw()
+        })
+
+        it('should error if lo is too large', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(0, Number.MAX_SAFE_INTEGER)).to.throw()
+        })
+
+        it('should error if lo is too small', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(0, Number.MIN_SAFE_INTEGER)).to.throw()
+        })
+
+        it('should error if lo is NaN', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(0, Number.NaN)).to.throw()
+        })
+
+        it('should error if lo is Infinity', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(0, Number.POSITIVE_INFINITY)).to.throw()
+        })
+
+        it('should error if lo is -Infinity', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(0, Number.NEGATIVE_INFINITY)).to.throw()
+        })
+
+        it('should error if lo is not an integer', async () => {
+            const i64 = new Int64(0)
+            expect(() => i64.setValue(0, 1.75)).to.throw()
         })
     })
 
@@ -40,17 +710,480 @@ describe('Int64', () => {
             const i64 = new Int64('0xffff')
             expect(i64.toDecimalString()).to.equal('65535')
         })
+
+        it('should correctly create a string representation of a negative number', async () => {
+            const i64 = new Int64(-54)
+            expect(i64.toDecimalString()).to.equal('-54')
+        })
+
+        it('should correctly handle the maximum safe integer', async () => {
+            const i64 = new Int64(9007199254740991)
+            expect(i64.toDecimalString()).to.equal('9007199254740991')
+        })
+
+        it('should correctly handle the minimum safe integer', async () => {
+            const i64 = new Int64(-9007199254740991)
+            expect(i64.toDecimalString()).to.equal('-9007199254740991')
+        })
+
+        it('should correctly handle 64-bit integers', async () => {
+            const i64 = Int64.fromDecimalString('9223372036854775807')
+            expect(i64.toDecimalString()).to.equal('9223372036854775807')
+        })
+
+        it('should correctly handle 64-bit negative integers', async () => {
+            const i64 = Int64.fromDecimalString('-9223372036854775808')
+            expect(i64.toDecimalString()).to.equal('-9223372036854775808')
+        })
+
+        it('should correctly handle the max safe integer + 1', async () => {
+            const i64 = Int64.fromDecimalString('9007199254740992')
+            expect(i64.toDecimalString()).to.equal('9007199254740992')
+        })
+
+        it('should correctly handle the min safe integer - 1', async () => {
+            const i64 = Int64.fromDecimalString('-9007199254740992')
+            expect(i64.toDecimalString()).to.equal('-9007199254740992')
+        })
+
+        it('should correctly handle the max safe integer + 2', async () => {
+            const i64 = Int64.fromDecimalString('9007199254740993')
+            expect(i64.toDecimalString()).to.equal('9007199254740993')
+        })
+
+        it('should correctly handle the min safe integer - 2', async () => {
+            const i64 = Int64.fromDecimalString('-9007199254740993')
+            expect(i64.toDecimalString()).to.equal('-9007199254740993')
+        })
+
+        it('should correctly handle the minimum Int64', async () => {
+            // This value is tricky because the 2's compliment is itself (still negative).
+            const i64 = new Int64('0x8000000000000000')
+            expect(i64.toDecimalString()).to.equal('-9223372036854775808')
+        })
     })
 
-    describe('static toDecimalString', () => {
-        it('should correctly create a string representation of number', async () => {
-            const i64 = new Int64(54)
-            expect(Int64.toDecimalString(i64)).to.equal('54')
+    describe('toNumber', () => {
+        describe('with default', () => {
+            it('should convert positive value', async () => {
+                const i64 = new Int64(Number.MAX_SAFE_INTEGER)
+                const octets = i64.toNumber()
+                expect(octets).to.equal(Number.MAX_SAFE_INTEGER)
+            })
+
+            it('should convert negative value', async () => {
+                const i64 = new Int64(Number.MIN_SAFE_INTEGER)
+                const octets = i64.toNumber()
+                expect(octets).to.equal(Number.MIN_SAFE_INTEGER)
+            })
+
+            it('should convert zero value', async () => {
+                const i64 = new Int64(0)
+                const octets = i64.toNumber()
+                expect(octets).to.equal(0)
+            })
+
+            it('should convert to imprecise positive value', async () => {
+                const i64 = new Int64(Int64.MAX_INT)
+                const octets = i64.toNumber()
+                expect(octets).to.equal(Int64.MAX_INT)
+            })
+
+            it('should convert to imprecise negative value', async () => {
+                const i64 = new Int64(Int64.MIN_INT)
+                const octets = i64.toNumber()
+                expect(octets).to.equal(Int64.MIN_INT)
+            })
         })
 
-        it('should correctly create a string representation of a hex number', async () => {
-            const i64 = new Int64('0xffff')
-            expect(Int64.toDecimalString(i64)).to.equal('65535')
+        describe('with allow imprecise = false', () => {
+            it('should convert positive value', async () => {
+                const i64 = new Int64(Number.MAX_SAFE_INTEGER)
+                const octets = i64.toNumber(false)
+                expect(octets).to.equal(Number.MAX_SAFE_INTEGER)
+            })
+
+            it('should convert negative value', async () => {
+                const i64 = new Int64(Number.MIN_SAFE_INTEGER)
+                const octets = i64.toNumber(false)
+                expect(octets).to.equal(Number.MIN_SAFE_INTEGER)
+            })
+
+            it('should convert zero value', async () => {
+                const i64 = new Int64(0)
+                const octets = i64.toNumber(false)
+                expect(octets).to.equal(0)
+            })
+
+            it('should convert positive imprecise value to infinity', async () => {
+                const i64 = new Int64(Int64.MAX_INT)
+                const octets = i64.toNumber(false)
+                expect(octets).to.equal(Infinity)
+            })
+
+            it('should convert negative imprecise value to -infinity', async () => {
+                const i64 = new Int64(Int64.MIN_INT)
+                const octets = i64.toNumber(false)
+                expect(octets).to.equal(-Infinity)
+            })
         })
+
+        describe('with allow imprecise = true', () => {
+            it('should convert positive value', async () => {
+                const i64 = new Int64(Number.MAX_SAFE_INTEGER)
+                const octets = i64.toNumber(true)
+                expect(octets).to.equal(Number.MAX_SAFE_INTEGER)
+            })
+
+            it('should convert negative value', async () => {
+                const i64 = new Int64(Number.MIN_SAFE_INTEGER)
+                const octets = i64.toNumber(true)
+                expect(octets).to.equal(Number.MIN_SAFE_INTEGER)
+            })
+
+            it('should convert zero value', async () => {
+                const i64 = new Int64(0)
+                const octets = i64.toNumber(true)
+                expect(octets).to.equal(0)
+            })
+
+            it('should convert to imprecise positive value', async () => {
+                const i64 = new Int64(Int64.MAX_INT)
+                const octets = i64.toNumber(true)
+                expect(octets).to.equal(Int64.MAX_INT)
+            })
+
+            it('should convert to imprecise negative value', async () => {
+                const i64 = new Int64(Int64.MIN_INT)
+                const octets = i64.toNumber(true)
+                expect(octets).to.equal(Int64.MIN_INT)
+            })
+        })
+    })
+
+    describe('valueOf', () => {
+        it('should convert positive value', async () => {
+            const i64 = new Int64(Number.MAX_SAFE_INTEGER)
+            const octets = i64.valueOf()
+            expect(octets).to.equal(Number.MAX_SAFE_INTEGER)
+        })
+
+        it('should convert negative value', async () => {
+            const i64 = new Int64(Number.MIN_SAFE_INTEGER)
+            const octets = i64.valueOf()
+            expect(octets).to.equal(Number.MIN_SAFE_INTEGER)
+        })
+
+        it('should convert zero value', async () => {
+            const i64 = new Int64(0)
+            const octets = i64.valueOf()
+            expect(octets).to.equal(0)
+        })
+
+        it('should convert positive imprecise value to infinity', async () => {
+            const i64 = new Int64(Int64.MAX_INT)
+            const octets = i64.valueOf()
+            expect(octets).to.equal(Infinity)
+        })
+
+        it('should convert negative imprecise value to -infinity', async () => {
+            const i64 = new Int64(Int64.MIN_INT)
+            const octets = i64.valueOf()
+            expect(octets).to.equal(-Infinity)
+        })
+    })
+
+    describe('toString', () => {
+        it('should format positive value', async () => {
+            const i64 = new Int64(Number.MAX_SAFE_INTEGER)
+            const octets = i64.toString()
+            expect(octets).to.equal('9007199254740991')
+        })
+
+        it('should format negative value', async () => {
+            const i64 = new Int64(Number.MIN_SAFE_INTEGER)
+            const octets = i64.toString()
+            expect(octets).to.equal('-9007199254740991')
+        })
+
+        it('should format zero value', async () => {
+            const i64 = new Int64(0)
+            const octets = i64.toString()
+            expect(octets).to.equal('0')
+        })
+
+        it('should format positive imprecise value', async () => {
+            const i64 = new Int64(Int64.MAX_INT)
+            const octets = i64.toString()
+            expect(octets).to.equal('Infinity')
+        })
+
+        it('should format negative imprecise value', async () => {
+            const i64 = new Int64(Int64.MIN_INT)
+            const octets = i64.toString()
+            expect(octets).to.equal('-Infinity')
+        })
+
+        it('should format positive value with radix', async () => {
+            const i64 = new Int64(255)
+            const octets = i64.toString(16)
+            expect(octets).to.equal('ff')
+        })
+
+        it('should format negative value with radix', async () => {
+            const i64 = new Int64(-255)
+            const octets = i64.toString(16)
+            expect(octets).to.equal('-ff')
+        })
+    })
+
+    describe('toOctetString', () => {
+        // Mix hex values to test zero padding and letter capitalization.
+        const TEST_HEX_BUFFER = Buffer.from([
+            0xa1,
+            0xb2,
+            0xc3,
+            0xd4,
+            0xe5,
+            0xf6,
+            0x07,
+            0x80,
+        ])
+        const i64 = new Int64(TEST_HEX_BUFFER)
+
+        it('should format with no separator', async () => {
+            const octets = i64.toOctetString()
+            expect(octets).to.equal('a1b2c3d4e5f60780')
+        })
+
+        it('should include leading zeros', async () => {
+            const octets = new Int64(0).toOctetString()
+            expect(octets).to.equal('0000000000000000')
+        })
+
+        it('should format with separator', async () => {
+            const octets = i64.toOctetString(' ')
+            expect(octets).to.equal('a1 b2 c3 d4 e5 f6 07 80')
+        })
+    })
+
+    describe('toBuffer', () => {
+        it('should copy the buffer by default', async () => {
+            const i64 = new Int64(1)
+            const buffer = i64.toBuffer()
+            expect(buffer).to.equal(i64.buffer)
+            expect(buffer).to.not.be.shallow.equal(i64.buffer)
+        })
+
+        it('should return raw buffer if requested', async () => {
+            const i64 = new Int64(1)
+            const buffer = i64.toBuffer(true)
+            expect(buffer).to.be.shallow.equal(i64.buffer)
+        })
+    })
+
+    describe('copy', () => {
+        it('should copy with no offset', async () => {
+            const i64 = new Int64(TEST_BUFFER)
+            const buffer = Buffer.alloc(8)
+            i64.copy(buffer)
+            const { data } = buffer.toJSON()
+            expect(data).to.equal([1, 2, 3, 4, 5, 6, 7, 8])
+        })
+
+        it('should only copy 8 bytes', async () => {
+            const i64 = new Int64(TEST_BUFFER)
+            const buffer = Buffer.alloc(10)
+            i64.copy(buffer)
+            const { data } = buffer.toJSON()
+            expect(data).to.equal([1, 2, 3, 4, 5, 6, 7, 8, 0, 0])
+        })
+
+        it('should copy with offset', async () => {
+            const i64 = new Int64(TEST_BUFFER)
+            const buffer = Buffer.alloc(10)
+            i64.copy(buffer, 2)
+            const { data } = buffer.toJSON()
+            expect(data).to.equal([0, 0, 1, 2, 3, 4, 5, 6, 7, 8])
+        })
+
+        it('should truncate', async () => {
+            const i64 = new Int64(TEST_BUFFER)
+            const buffer = Buffer.alloc(8)
+            i64.copy(buffer, 2)
+            const { data } = buffer.toJSON()
+            expect(data).to.equal([0, 0, 1, 2, 3, 4, 5, 6])
+        })
+    })
+
+    describe('compare', () => {
+        it('should be 0 for equal numbers', () => {
+            const v1 = new Int64(123)
+            const v2 = new Int64(123)
+            const result = v1.compare(v2)
+            expect(result).to.equal(0)
+        })
+
+        it('should be greater than 0 for greater than', () => {
+            const v1 = new Int64(2)
+            const v2 = new Int64(1)
+            const result = v1.compare(v2)
+            expect(result).to.be.greaterThan(0)
+        })
+
+        it('should be less than 0 for less than', () => {
+            const v1 = new Int64(1)
+            const v2 = new Int64(2)
+            const result = v1.compare(v2)
+            expect(result).to.be.lessThan(0)
+        })
+
+        it('should be greater than 0 for positive vs. negative numbers', () => {
+            const v1 = new Int64(1)
+            const v2 = new Int64(-1)
+            const result = v1.compare(v2)
+            expect(result).to.be.greaterThan(0)
+        })
+
+        it('should be less than 0 for negative vs. positive numbers', () => {
+            const v1 = new Int64(-1)
+            const v2 = new Int64(1)
+            const result = v1.compare(v2)
+            expect(result).to.be.lessThan(0)
+        })
+
+        it('should sort positive and negative numbers', () => {
+            const values = [
+                new Int64(123),
+                new Int64(0),
+                new Int64(123),
+                new Int64(-1),
+                new Int64(1),
+                new Int64(-2),
+                new Int64(2),
+                new Int64(Number.MAX_SAFE_INTEGER),
+                new Int64(Number.MIN_SAFE_INTEGER),
+                Int64.fromDecimalString('-9223372036854775808'),
+                Int64.fromDecimalString('9223372036854775807'),
+            ]
+            const sorted = values
+                .sort((b1, b2) => b1.compare(b2))
+                .map((v) => v.toDecimalString())
+            expect(sorted).to.equal([
+                '-9223372036854775808',
+                '-9007199254740991',
+                '-2',
+                '-1',
+                '0',
+                '1',
+                '2',
+                '123',
+                '123',
+                '9007199254740991',
+                '9223372036854775807',
+            ])
+        })
+    })
+
+    describe('equals', () => {
+        it('should be true for equal numbers', () => {
+            const v1 = new Int64(123)
+            const v2 = new Int64(123)
+            const result = v1.equals(v2)
+            expect(result).to.be.true()
+        })
+
+        it('should be false for greater than', () => {
+            const v1 = new Int64(2)
+            const v2 = new Int64(1)
+            const result = v1.equals(v2)
+            expect(result).to.be.false()
+        })
+
+        it('should be false for less than', () => {
+            const v1 = new Int64(1)
+            const v2 = new Int64(2)
+            const result = v1.equals(v2)
+            expect(result).to.be.false()
+        })
+
+        it('should be false for the same absolute value', () => {
+            const v1 = new Int64(1)
+            const v2 = new Int64(-1)
+            const result = v1.equals(v2)
+            expect(result).to.be.false()
+        })
+    })
+
+    describe('inspect', () => {
+        it('should format positive value and octets', async () => {
+            const i64 = new Int64(Number.MAX_SAFE_INTEGER)
+            const octets = i64.inspect()
+            expect(octets).to.equal(
+                '[Int64 value:9007199254740991 octets:00 1f ff ff ff ff ff ff]',
+            )
+        })
+
+        it('should format negative value and octets', async () => {
+            const i64 = new Int64(Number.MIN_SAFE_INTEGER)
+            const octets = i64.inspect()
+            expect(octets).to.equal(
+                '[Int64 value:-9007199254740991 octets:ff e0 00 00 00 00 00 01]',
+            )
+        })
+
+        it('should format zero value and octets', async () => {
+            const i64 = new Int64(0)
+            const octets = i64.inspect()
+            expect(octets).to.equal(
+                '[Int64 value:0 octets:00 00 00 00 00 00 00 00]',
+            )
+        })
+
+        it('should format positive imprecise value', async () => {
+            const i64 = new Int64(Int64.MAX_INT)
+            const octets = i64.inspect()
+            expect(octets).to.equal(
+                '[Int64 value:Infinity octets:00 20 00 00 00 00 00 00]',
+            )
+        })
+
+        it('should format negative imprecise value', async () => {
+            const i64 = new Int64(Int64.MIN_INT)
+            const octets = i64.inspect()
+            expect(octets).to.equal(
+                '[Int64 value:-Infinity octets:ff e0 00 00 00 00 00 00]',
+            )
+        })
+    })
+})
+
+describe('isInt64', () => {
+    it('true for Int64', () => {
+        expect(isInt64(new Int64('0'))).to.be.true()
+    })
+
+    it('true for Int64-like object', () => {
+        expect(isInt64(new LikeInt64('0'))).to.be.true()
+    })
+
+    it('false if no buffer', () => {
+        expect(
+            isInt64((new NoBufferInt64('0') as object) as IInt64),
+        ).to.be.false()
+    })
+
+    it('false if buffer length < 8', () => {
+        expect(isInt64((new Int56('0') as object) as IInt64)).to.be.false()
+    })
+
+    it('false if buffer length > 8', () => {
+        expect(isInt64((new Int72('0') as object) as IInt64)).to.be.false()
+    })
+
+    it('false if no toDecimalString()', () => {
+        expect(
+            isInt64((new NoStringInt64('0') as object) as IInt64),
+        ).to.be.false()
     })
 })

--- a/packages/thrift-server-core/src/tests/unit/types.ts
+++ b/packages/thrift-server-core/src/tests/unit/types.ts
@@ -1,0 +1,93 @@
+import { IInt64, Int64 } from '../../main'
+
+/**
+ * Test class compatible with Int64.
+ */
+export class LikeInt64 implements IInt64 {
+    /** @inheritDoc */
+    public readonly buffer: Buffer
+
+    private readonly i64: Int64
+
+    constructor(value: string) {
+        this.i64 = Int64.fromDecimalString(value)
+        this.buffer = this.i64.buffer
+    }
+
+    /** @inheritDoc */
+    public toDecimalString(): string {
+        return this.i64.toDecimalString()
+    }
+}
+
+/**
+ * Test class with no buffer.
+ */
+export class NoBufferInt64 implements Omit<IInt64, 'buffer'> {
+    private readonly i64: Int64
+
+    constructor(value: string) {
+        this.i64 = Int64.fromDecimalString(value)
+    }
+
+    /** @inheritDoc */
+    public toDecimalString(): string {
+        return this.i64.toDecimalString()
+    }
+}
+
+/**
+ * Test class with no toDecimalString().
+ */
+export class NoStringInt64 implements Omit<IInt64, 'toDecimalString'> {
+    /** @inheritDoc */
+    public readonly buffer: Buffer
+
+    private readonly i64: Int64
+
+    constructor(value: string) {
+        this.i64 = Int64.fromDecimalString(value)
+        this.buffer = this.i64.buffer
+    }
+}
+
+/**
+ * Test class with a shorter buffer.
+ */
+export class Int56 implements IInt64 {
+    /** @inheritDoc */
+    public readonly buffer: Buffer
+
+    private readonly i64: Int64
+
+    constructor(value: string) {
+        this.i64 = Int64.fromDecimalString(value)
+        this.buffer = this.i64.buffer.slice(1)
+    }
+
+    /** @inheritDoc */
+    public toDecimalString(): string {
+        return this.i64.toDecimalString()
+    }
+}
+
+/**
+ * Test class with a longer buffer.
+ */
+export class Int72 implements IInt64 {
+    /** @inheritDoc */
+    public readonly buffer: Buffer
+
+    private readonly i64: Int64
+
+    constructor(value: string) {
+        this.i64 = Int64.fromDecimalString(value)
+        this.buffer = Buffer.alloc(9)
+        this.i64.buffer.copy(this.buffer, 1)
+    }
+
+    /** @inheritDoc */
+    public toDecimalString(): string {
+        return this.i64.toDecimalString()
+    }
+}

--- a/packages/zipkin-core/src/main/utils.ts
+++ b/packages/zipkin-core/src/main/utils.ts
@@ -148,9 +148,9 @@ export function traceIdForHeaders(headers: IRequestHeaders): ITraceId {
 
 export function normalizeHeaders(headers: IRequestHeaders): IRequestHeaders {
     if (headers[L5D_TRACE_HDR] !== undefined) {
-        const linkerDTrace = deserializeLinkerdHeader(headers[
-            L5D_TRACE_HDR
-        ] as string)
+        const linkerDTrace = deserializeLinkerdHeader(
+            headers[L5D_TRACE_HDR] as string,
+        )
         if (
             headers[ZipkinHeaders.TraceId] !== undefined &&
             headers[ZipkinHeaders.TraceId] !== linkerDTrace.traceId


### PR DESCRIPTION
## Description
Enhancements:
* Added `IInt64` interface and type check.
* Support writing 64-bit integers that match the interface and not just an `instanceof Int64`.

Fixes:
* Fixes for `Int64` created from a buffer and offset.
* Fix negative check for `toDecimalString()` (bit operations on numbers from the buffer are 32-bit, not 8-bit).
* Add tests and handling for NaN, Infinity, and -Infinity when setting the Int64 value from number(s).
* Add tests for existing `Int64` functionality and protocols.

Leverage integration with `Buffer`:
* Re-implement many of the number methods using `Buffer` number methods instead of byte-by-byte implementations.
* Using the existing `Buffer` functionality greatly reduced the size of the code. This PR is only a large positive delta because of all the added tests. The bitwise operators are also not as efficient as they might seem if you are used to using them in a lower-level language. They actually convert the number/double to a 32-bit integer to perform the operations.

Remove public `_2scomp()` method:
* Remove `_2scomp()` public method that looks like it was intended to be private but ended up being used in the `CompactProtocol`.
* Handle the -1 case in the `CompactProtocol` without using `_2scomp()` (it was just converting 1 to -1 and extracting the high and low 32-bits which are just 0xffffffff).
* There is a new 2's complement function based on numbers instead of bytes but it is not exported.
* Writing an `Int64` using the `CompactProtocol` should no longer mutate the `Int64` value.

## Motivation and Context
When multiple packages depend on `@creditkarma/thrift-server-core`, they may have different versions. This results in duplicates in different `node_modules` paths. Some may even be the same version but if there is not a common parent version they may be split between different siblings.

The `instanceof` check between these different instances of `Int64` is false. The `writeI64()` methods in the protocol implementations checked for `instanceof Int64` and failed.

Switch to an interface and more flexible type check. The `Buffer` type is the Node type and should match `instanceof Buffer` across packages.

While making the fixes, I started adding tests because test coverage was poor. In doing so I found more issues and ended up making more fixes. It's possible to make a smaller PR just for the `instanceof Int64` issue if desired.

Note that all unit tests were written and passed the byte-by-byte implementations before the change to the number implementations.

TODO: The double behavior for non-finite values is inconsistent across protocols. Removing the check for NaN in the `BinaryProtocol` would make it match the `CompactProtocol` and other implementations I see in other languages for the `BinaryProtocol`. Making the JSON protocol consistent would require more work around the JSON parser. A further tweak to the JSON writing would be required to handle `-0`.

## How Has This Been Tested?
Tested end-to-end in a service.
Much improved unit test coverage.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - Removed the `_2scomp()` public method which probably should not have been public in the first place.
  - Fixed the `toBuffer()` type which could potentially break something that tried to strictly match the old type.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
