### PR TITLE
fix: Make Int64.fromDecimalString() act more like parseInt()

### DIFF
--- a/packages/thrift-server-core/src/tests/unit/Int64.spec.ts
+++ b/packages/thrift-server-core/src/tests/unit/Int64.spec.ts
@@ -11,6 +11,9 @@ const it = lab.it
 
 describe('Int64', () => {
     const TEST_STRING: string = '9837756439'
+    // Decimal number larger than the max safe integer.
+    // As a number, this becomes 9007199254741112.
+    const TEST_UNSAFE_STRING = '9007199254741113'
     const TOO_LARGE: string = '999999999999999999999999999999'
     const TEST_BUFFER = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
@@ -67,13 +70,110 @@ describe('Int64', () => {
     })
 
     describe('static fromDecimalString', () => {
-        it('should correctly create Int64 from string', async () => {
+        it('should correctly create Int64 from safe integer', async () => {
             const i64 = Int64.fromDecimalString(TEST_STRING)
             expect(i64.toDecimalString()).to.equal(TEST_STRING)
         })
 
+        it('should correctly create Int64 from unsafe integer', async () => {
+            const i64 = Int64.fromDecimalString(TEST_UNSAFE_STRING)
+            expect(i64.toDecimalString()).to.equal(TEST_UNSAFE_STRING)
+        })
+
+        it('should correctly create Int64 from negative safe integer', async () => {
+            const i64 = Int64.fromDecimalString(`-${TEST_STRING}`)
+            expect(i64.toDecimalString()).to.equal(`-${TEST_STRING}`)
+        })
+
+        it('should correctly create Int64 from negative unsafe integer', async () => {
+            const i64 = Int64.fromDecimalString(`-${TEST_UNSAFE_STRING}`)
+            expect(i64.toDecimalString()).to.equal(`-${TEST_UNSAFE_STRING}`)
+        })
+
         it('should throw if the decimal string is too large for Int64', async () => {
             expect(() => Int64.fromDecimalString(TOO_LARGE)).to.throw()
+        })
+
+        it('should stop at space', async () => {
+            const i64 = Int64.fromDecimalString(`${TEST_STRING} 1`)
+            expect(i64.toDecimalString()).to.equal(TEST_STRING)
+        })
+
+        it('should stop unsafe integer at space', async () => {
+            const i64 = Int64.fromDecimalString(`${TEST_UNSAFE_STRING} 1`)
+            expect(i64.toDecimalString()).to.equal(TEST_UNSAFE_STRING)
+        })
+
+        it('should stop negative integer at space', async () => {
+            const i64 = Int64.fromDecimalString(`-${TEST_STRING} 1`)
+            expect(i64.toDecimalString()).to.equal(`-${TEST_STRING}`)
+        })
+
+        it('should stop negative unsafe integer at space', async () => {
+            const i64 = Int64.fromDecimalString(`-${TEST_UNSAFE_STRING} 1`)
+            expect(i64.toDecimalString()).to.equal(`-${TEST_UNSAFE_STRING}`)
+        })
+
+        it('should stop at non-digit', async () => {
+            const i64 = Int64.fromDecimalString(`${TEST_STRING}a`)
+            expect(i64.toDecimalString()).to.equal(TEST_STRING)
+        })
+
+        it('should stop unsafe integer at non-digit', async () => {
+            const i64 = Int64.fromDecimalString(`${TEST_UNSAFE_STRING}a`)
+            expect(i64.toDecimalString()).to.equal(TEST_UNSAFE_STRING)
+        })
+
+        it('should stop negative integer at non-digit', async () => {
+            const i64 = Int64.fromDecimalString(`-${TEST_STRING}a`)
+            expect(i64.toDecimalString()).to.equal(`-${TEST_STRING}`)
+        })
+
+        it('should stop negative unsafe integer at non-digit', async () => {
+            const i64 = Int64.fromDecimalString(`-${TEST_UNSAFE_STRING}a`)
+            expect(i64.toDecimalString()).to.equal(`-${TEST_UNSAFE_STRING}`)
+        })
+
+        it('should handle empty string as zero', async () => {
+            const i64 = Int64.fromDecimalString('')
+            expect(i64.toDecimalString()).to.equal('0')
+        })
+
+        it('should handle non-numeric string as zero', async () => {
+            const i64 = Int64.fromDecimalString('invalid')
+            expect(i64.toDecimalString()).to.equal('0')
+        })
+
+        it('should handle long non-numeric string as zero', async () => {
+            // Long and short strings are handled differently. Test a longer string.
+            const i64 = Int64.fromDecimalString('z'.repeat(18))
+            expect(i64.toDecimalString()).to.equal('0')
+        })
+
+        it('should handle "negative" non-numeric string as zero', async () => {
+            const i64 = Int64.fromDecimalString('-invalid')
+            expect(i64.toDecimalString()).to.equal('0')
+        })
+
+        it('should handle long "negative" non-numeric string as zero', async () => {
+            // Long and short strings are handled differenlty. Test a longer string.
+            const i64 = Int64.fromDecimalString('-' + 'z'.repeat(18))
+            expect(i64.toDecimalString()).to.equal('0')
+        })
+
+        it('should handle "Infinity" as an invalid string (zero)', async () => {
+            const i64 = Int64.fromDecimalString('Infinity')
+            expect(i64.toDecimalString()).to.equal('0')
+        })
+
+        it('should handle "-Infinity" as an invalid string (zero)', async () => {
+            const i64 = Int64.fromDecimalString('-Infinity')
+            expect(i64.toDecimalString()).to.equal('0')
+        })
+
+        it('should handle "-" as an invalid string (zero)', async () => {
+            const i64 = Int64.fromDecimalString('-Infinity')
+            expect(i64.toDecimalString()).to.equal('0')
         })
     })
 


### PR DESCRIPTION
Make `Int64.fromDecimalString()` behave more like `parseInt()`.

## Description
After releasing v0.16.0, we found that some code was passing in a non-numeric strings and expecting a zero value.

The `parseInt()` function returns `NaN` for non-numeric strings but this was getting converted to `0` in earlier versions that were not checking the input for a valid value. This become an error with v0.16.0. Make it zero again.

Handle strings with a numeric prefix as parseInt() as well. Just convert the numeric prefix, ignoring the rest of the string. The old code would try to convert the whole string to a number without extracting just the numeric parts. This could result in `NaN` high or low parts with unexpected results.

## Motivation and Context
This caused some regressions in early adopters. These were mostly tests for edge cases but delayed releases.

Avoid more widespread regressions.

## How Has This Been Tested?
More extensive unit tests for the edge cases around unexpected strings for `Int64.fromDecimalString()`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
