### PR TITLE
feat: Injectable request

### DIFF
--- a/packages/thrift-client/README.md
+++ b/packages/thrift-client/README.md
@@ -97,6 +97,7 @@ The available options are:
 * protocol (optional): Name of the Thrift protocol type to use. Defaults to 'binary'.
 * requestOptions (optional): Options to pass to the underlying [Request library](https://github.com/request/request#requestoptions-callback). Defaults to {}.
 * register (optional): A list of filters to apply to your client. More on this later.
+* requestImpl (optional): Provide a request implementation. Defaults to 'request' module.
 
 Currently `@creditkarma/thrift-server-core"` only supports buffered transport and binary or compact protocols.
 

--- a/packages/thrift-client/src/main/connections/HttpConnection.ts
+++ b/packages/thrift-client/src/main/connections/HttpConnection.ts
@@ -1,7 +1,6 @@
 import * as Core from '@creditkarma/thrift-server-core'
 
-import request = require('request')
-
+import * as request from 'request'
 import {
     Request,
     RequestAPI,
@@ -127,6 +126,7 @@ export class HttpConnection extends Core.ThriftConnection<RequestOptions> {
     private readonly requestOptions: RequestOptions
     private readonly serviceName: string | undefined
     private readonly withEndpointPerMethod: boolean
+    private readonly requestImpl: typeof request
 
     constructor({
         hostName,
@@ -139,6 +139,7 @@ export class HttpConnection extends Core.ThriftConnection<RequestOptions> {
         serviceName,
         withEndpointPerMethod = false,
         headerBlacklist = [],
+        requestImpl = request,
     }: IHttpConnectionOptions) {
         super(Core.getTransport(transport), Core.getProtocol(protocol))
         this.requestOptions = Object.freeze(
@@ -153,6 +154,7 @@ export class HttpConnection extends Core.ThriftConnection<RequestOptions> {
         this.withEndpointPerMethod = withEndpointPerMethod
         this.url = `${this.basePath}${this.path}`
         this.filters = []
+        this.requestImpl = requestImpl
     }
 
     public register(
@@ -234,7 +236,7 @@ export class HttpConnection extends Core.ThriftConnection<RequestOptions> {
         )
 
         return new Promise((resolve, reject) => {
-            request(
+            this.requestImpl(
                 requestOptions,
                 (err: any, response: RequestResponse, body: Buffer) => {
                     if (

--- a/packages/thrift-client/src/main/types.ts
+++ b/packages/thrift-client/src/main/types.ts
@@ -62,6 +62,7 @@ export interface IHttpConnectionOptions {
     requestOptions?: RequestOptions
     withEndpointPerMethod?: boolean
     headerBlacklist?: Array<string>
+    requestImpl?: typeof request
 }
 
 export interface ICreateHttpClientOptions extends IHttpConnectionOptions {


### PR DESCRIPTION
## Description

Add an optional `requestImpl` to `HttpConnection` constructor to allow users to provide their own `request` implementation.  By default, the normal `request` module will be used.

## Motivation and Context

Allowing `request` to be injected is useful for various instrumentation tasks like adding/modifying headers, timing, and faciliating integrations that rely on wrapping `request`.

## How Has This Been Tested?

A new test case was added to `thrift-integration`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
