### PR TITLE
Add a StructLike class that extends Error.

### DIFF
--- a/packages/thrift-server-core/src/main/types.ts
+++ b/packages/thrift-server-core/src/main/types.ts
@@ -86,6 +86,22 @@ export abstract class StructLike implements IStructLike {
     public abstract write(output: TProtocol): void
 }
 
+/**
+ * Like `StructLike` but extends `Error`. Exception classes extend this.
+ */
+export abstract class ErrorStructLike extends Error implements IStructLike {
+    public readonly name: string
+    public readonly _annotations: IThriftAnnotations = {}
+    public readonly _fieldAnnotations: IFieldAnnotations = {}
+
+    constructor() {
+        super()
+        this.name = this.constructor.name
+    }
+
+    public abstract write(output: TProtocol): void
+}
+
 export interface IStructConstructor<T extends StructLike> {
     new (args?: any): T
     read(input: TProtocol): T


### PR DESCRIPTION
## Description
Exception classes should extend this so that they derive from Error.

## Motivation and Context
As mentioned in [the thrift-typescript GitHub issue](https://github.com/creditkarma/thrift-typescript/issues/178), it's useful for exceptions to derive from Error so they have stack traces and because some frameworks expect it. The GitHub issue mentions graphql-js. Jest's `toThrow()` function would also benefit from this. See the related thrift-typescript PR for more details.

## How Has This Been Tested?
Tested locally.

## Possible remaining work:
- Add a test?
- Bump version number so end users can require the new version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
