### PR TITLE
Read-only tags for LogFunction

### DIFF
--- a/packages/thrift-server-core/src/main/logger.ts
+++ b/packages/thrift-server-core/src/main/logger.ts
@@ -1,7 +1,7 @@
 import { LogFunction } from './types'
 
 export const makeLogger = (name: string): LogFunction => {
-    return (tags: Array<string>, data?: string | object): void => {
+    return (tags: ReadonlyArray<string>, data?: string | object): void => {
         const allTags: Array<string> = Array.from(new Set([name, ...tags]))
         if (allTags.indexOf('error') > -1) {
             if (data !== undefined) {

--- a/packages/thrift-server-core/src/main/types.ts
+++ b/packages/thrift-server-core/src/main/types.ts
@@ -3,7 +3,7 @@ import { TTransport } from './transports'
 
 export * from './Int64'
 
-export type LogFunction = (tags: ReadArray<string>, data?: string | object) => void
+export type LogFunction = (tags: ReadonlyArray<string>, data?: string | object) => void
 
 export interface IRequestHeaders {
     [name: string]: any

--- a/packages/thrift-server-core/src/main/types.ts
+++ b/packages/thrift-server-core/src/main/types.ts
@@ -3,7 +3,10 @@ import { TTransport } from './transports'
 
 export * from './Int64'
 
-export type LogFunction = (tags: ReadonlyArray<string>, data?: string | object) => void
+export type LogFunction = (
+    tags: ReadonlyArray<string>,
+    data?: string | object,
+) => void
 
 export interface IRequestHeaders {
     [name: string]: any

--- a/packages/thrift-server-core/src/main/types.ts
+++ b/packages/thrift-server-core/src/main/types.ts
@@ -3,7 +3,7 @@ import { TTransport } from './transports'
 
 export * from './Int64'
 
-export type LogFunction = (tags: Array<string>, data?: string | object) => void
+export type LogFunction = (tags: ReadArray<string>, data?: string | object) => void
 
 export interface IRequestHeaders {
     [name: string]: any


### PR DESCRIPTION
## Description
Allow passing in a read-only array for the tags when logging.

## Motivation and Context
Allow constant arrays for tags.

## How Has This Been Tested?
Tested with a caller passing `ReadonlyArray<string>` tags.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
