### PR TITLE
Distribute dist/ttwitter in addition to dist/main for thrift-client-ttwitter-filter

### DIFF
--- a/packages/thrift-client-ttwitter-filter/package.json
+++ b/packages/thrift-client-ttwitter-filter/package.json
@@ -5,7 +5,8 @@
     "main": "dist/main/index.js",
     "types": "dist/main/index.d.ts",
     "files": [
-        "dist/main"
+        "dist/main",
+        "dist/ttwitter"
     ],
     "keywords": [],
     "scripts": {


### PR DESCRIPTION
The thrift ttwitter filter is broken, and trying to use it produces this error: `Error: Cannot find module '../ttwitter/com/creditkarma/finagle/thrift'`

## Description
Fixes the bug outlined in https://github.com/creditkarma/thrift-server/issues/108
